### PR TITLE
console/ast2400: Fix SIO address for SUART configuration

### DIFF
--- a/src/usr/console/ast2400.C
+++ b/src/usr/console/ast2400.C
@@ -84,11 +84,11 @@ namespace CONSOLE
 
             do{
 
-                l_err = _writeReg( SIO_ADDR_REG_2E, i_data );
+                l_err = _writeReg( SIO_ADDR_REG_2E, i_reg );
 
                 if(l_err) { break; }
 
-                l_err = _writeReg( SIO_DATA_REG_2F, i_reg );
+                l_err = _writeReg( SIO_DATA_REG_2F, i_data );
 
             }while(0);
 

--- a/src/usr/console/ast2400.C
+++ b/src/usr/console/ast2400.C
@@ -6,6 +6,7 @@
 /* OpenPOWER HostBoot Project                                             */
 /*                                                                        */
 /* Contributors Listed Below - COPYRIGHT 2014,2015                        */
+/* [+] <jk@ozlabs.org                                                     */
 /* [+] International Business Machines Corp.                              */
 /*                                                                        */
 /*                                                                        */
@@ -242,7 +243,7 @@ namespace CONSOLE
                 l_errl = writeSIOReg( 0x60, (g_uartBase >> 8) & 0xFF );
                 if (l_errl) { break; }
 
-                l_errl = writeSIOReg( 61, (g_uartBase & 0xFF) );
+                l_errl = writeSIOReg( 0x61, (g_uartBase & 0xFF) );
                 if (l_errl) { break; }
 
                 // Set the SerIRQ


### PR DESCRIPTION
The SUART1 base address is at 60 hex, not 60 decimal.

Luckily, we've been setting it (from g_uartBase) to the default value
of 0xf8.

Signed-off-by: Jeremy Kerr <jk@ozlabs.org>