### PR TITLE
Fix building with binutils 2.25

### DIFF
--- a/src/build/linker/makefile
+++ b/src/build/linker/makefile
@@ -26,7 +26,7 @@ ROOTPATH = ../../..
 
 ifdef HOST_BINUTILS_DIR
 BFD_CFLAGS = -I$(HOST_BINUTILS_DIR)/bfd/ -I$(HOST_BINUTILS_DIR)/include/
-BFD_LDFLAGS = $(HOST_BINUTILS_DIR)/bfd/libbfd.a \
+BFD_LDFLAGS = $(HOST_BINUTILS_DIR)/bfd/libbfd.a -ldl \
 	      $(HOST_BINUTILS_DIR)/libiberty/libiberty.a -lz
 else
 BFD_LDFLAGS = -lbfd -liberty -lz

--- a/src/build/trace/makefile
+++ b/src/build/trace/makefile
@@ -29,7 +29,7 @@ CLEAN_TARGETS += tracehash tracehash.o
 
 ifdef HOST_BINUTILS_DIR
 BFD_CFLAGS = -I$(HOST_BINUTILS_DIR)/bfd/ -I$(HOST_BINUTILS_DIR)/include/
-BFD_LDFLAGS = $(HOST_BINUTILS_DIR)/bfd/libbfd.a \
+BFD_LDFLAGS = $(HOST_BINUTILS_DIR)/bfd/libbfd.a -ldl \
 	      $(HOST_BINUTILS_DIR)/libiberty/libiberty.a -lz
 else
 BFD_LDFLAGS = -lbfd


### PR DESCRIPTION
We need to explicitly link with -ldl with binutils 2.25

Suggested-by: A. Patrick Williams III <iawillia@us.ibm.com>
Fixes: https://github.com/open-power/hostboot/issues/31
Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>