### PR TITLE
Gcc6 fixes

### DIFF
--- a/src/build/mkrules/cflags.env.mk
+++ b/src/build/mkrules/cflags.env.mk
@@ -41,7 +41,7 @@ CFLAGS += $(COMMONFLAGS) -mcpu=power7 -nostdinc -g -mno-vsx -mno-altivec\
 	  -ffunction-sections -fdata-sections -ffreestanding -mbig-endian
 ASMFLAGS += $(COMMONFLAGS) -mcpu=power7 -mbig-endian
 CXXFLAGS += $(CFLAGS) -nostdinc++ -fno-rtti -fno-exceptions -Wall \
-	    -fuse-cxa-atexit
+	    -fuse-cxa-atexit -std=gnu++03
 LDFLAGS += --nostdlib --sort-common -EB $(COMMONFLAGS)
 
 INCFLAGS = $(addprefix -I, $(INCDIR) )

--- a/src/include/kernel/cpumgr.H
+++ b/src/include/kernel/cpumgr.H
@@ -215,7 +215,7 @@ class CpuManager
              */
         static uint64_t cv_cpuSeq;
 
-        static bool cv_forcedMemPeriodic;       //!<  force free / coalesce.
+        static int cv_forcedMemPeriodic;       //!<  force free / coalesce.
 
         // If a shutdown of all CPUs is requested
         static bool cv_shutdown_requested;

--- a/src/include/usr/devicefw/driverif.H
+++ b/src/include/usr/devicefw/driverif.H
@@ -266,7 +266,7 @@ namespace DeviceFW
                              TargType i_targetType,
                              deviceOp_t i_regRoute)
     {
-        return InvalidParameterType(); // Cause a compile fail if not one of
+        InvalidParameterType(); // Cause a compile fail if not one of
                                        // the explicit template specializations.
     }
 

--- a/src/include/usr/hwpf/hwp/mvpd_accessors/getMBvpdAttr.H
+++ b/src/include/usr/hwpf/hwp/mvpd_accessors/getMBvpdAttr.H
@@ -227,6 +227,13 @@ namespace getAttrData
         uint8_t              iv_systemType;
         uint8_t              iv_systemType_ext;
         uint8_t              iv_dataVersion;
+    public:
+	MBvpdVMKeyword() : iv_version(0),iv_systemType(0),
+			   iv_systemType_ext(0),iv_dataVersion(0) {};
+	operator uint32_t() const {
+		return iv_version << 24 | iv_systemType << 16 |
+			iv_systemType_ext << 8 | iv_dataVersion;
+	}
     };
 //  Attribute definition
     struct MBvpdAttrDef

--- a/src/include/usr/hwpf/hwp/mvpd_accessors/getMBvpdMemoryDataVersion.H
+++ b/src/include/usr/hwpf/hwp/mvpd_accessors/getMBvpdMemoryDataVersion.H
@@ -33,7 +33,6 @@
 #define _HWP_GETMBVPDMEMDATAVERSION_
 
 #include <fapi.H>
-#define VM_KEYWORD_DEFAULT_VALUE 0x00000000
 
 // function pointer typedef definition for HWP call support
 typedef fapi::ReturnCode (*getMBvpdMemoryDataVersion_FP_t)

--- a/src/kernel/cpumgr.C
+++ b/src/kernel/cpumgr.C
@@ -50,7 +50,7 @@ cpu_t** CpuManager::cv_cpus[KERNEL_MAX_SUPPORTED_NODES];
 bool CpuManager::cv_shutdown_requested = false;
 uint64_t CpuManager::cv_shutdown_status = 0;
 size_t CpuManager::cv_cpuSeq = 0;
-bool CpuManager::cv_forcedMemPeriodic = false;
+int CpuManager::cv_forcedMemPeriodic = 0;
 InteractiveDebug CpuManager::cv_interactive_debug;
 
 CpuManager::CpuManager() : iv_lastStartTimebase(0)
@@ -361,7 +361,7 @@ void CpuManager::executePeriodics(cpu_t * i_cpu)
         }
 
         bool forceMemoryPeriodic = __sync_fetch_and_and(&cv_forcedMemPeriodic,
-                                                        false);
+                                                        0);
 
         ++(i_cpu->periodic_count);
         if((0 == (i_cpu->periodic_count % CPU_PERIODIC_CHECK_MEMORY)) ||
@@ -461,7 +461,7 @@ size_t CpuManager::getThreadCount()
 
 void CpuManager::forceMemoryPeriodic()
 {
-    cv_forcedMemPeriodic = true;
+    cv_forcedMemPeriodic = 1;
 }
 
 

--- a/src/usr/diag/prdf/common/framework/register/prdfErrorRegister.C
+++ b/src/usr/diag/prdf/common/framework/register/prdfErrorRegister.C
@@ -120,8 +120,6 @@ ErrorRegister::ErrorRegister( SCAN_COMM_REGISTER_CLASS & r, ResolutionMap & rm,
     ErrorRegisterType(), scr(r), scr_rc(SUCCESS), rMap(rm),
     xNoErrorOnZeroScr(false), xScrId(scrId)
 {
-    PRDF_ASSERT( &r  != NULL );
-    PRDF_ASSERT( &rm != NULL );
 }
 
 /*---------------------------------------------------------------------*/

--- a/src/usr/diag/prdf/common/framework/register/prdfOperatorRegister.H
+++ b/src/usr/diag/prdf/common/framework/register/prdfOperatorRegister.H
@@ -434,15 +434,15 @@ class AttnTypeRegister : public SCAN_COMM_REGISTER_CLASS
         iv_bs = &iv_iBS;
     }
 
-    AttnTypeRegister( SCAN_COMM_REGISTER_CLASS & i_check,
-                      SCAN_COMM_REGISTER_CLASS & i_recov,
-                      SCAN_COMM_REGISTER_CLASS & i_special,
-                      SCAN_COMM_REGISTER_CLASS & i_proccs ) :
+    AttnTypeRegister( SCAN_COMM_REGISTER_CLASS *i_check,
+                      SCAN_COMM_REGISTER_CLASS *i_recov,
+                      SCAN_COMM_REGISTER_CLASS *i_special,
+                      SCAN_COMM_REGISTER_CLASS *i_proccs ) :
         SCAN_COMM_REGISTER_CLASS( ),
-        iv_check(  NULL == &i_check   ? &cv_null : &i_check),
-        iv_recov(  NULL == &i_recov   ? &cv_null : &i_recov),
-        iv_special(NULL == &i_special ? &cv_null : &i_special),
-        iv_proccs( NULL == &i_proccs  ? &cv_null : &i_proccs),
+        iv_check(  NULL == i_check   ? &cv_null : i_check),
+        iv_recov(  NULL == i_recov   ? &cv_null : i_recov),
+        iv_special(NULL == i_special ? &cv_null : i_special),
+        iv_proccs( NULL == i_proccs  ? &cv_null : i_proccs),
         iv_iBS(0)         // will fully initialize this inside ctor.
     {
         uint32_t l_length = 1024;

--- a/src/usr/diag/prdf/common/framework/register/prdfScanFacility.C
+++ b/src/usr/diag/prdf/common/framework/register/prdfScanFacility.C
@@ -166,7 +166,7 @@ SCAN_COMM_REGISTER_CLASS &  ScanFacility::GetAttnTypeRegister(
                                            SCAN_COMM_REGISTER_CLASS * i_special,
                                            SCAN_COMM_REGISTER_CLASS * i_proccs )
 {
-  AttnTypeRegister r(*i_check, *i_recov, *i_special, *i_proccs);
+  AttnTypeRegister r(i_check, i_recov, i_special, i_proccs);
   return iv_attnRegFw.get(r);
 }
 

--- a/src/usr/hwpf/hwp/mvpd_accessors/getMBvpdAttr.C
+++ b/src/usr/hwpf/hwp/mvpd_accessors/getMBvpdAttr.C
@@ -392,7 +392,7 @@ fapi::ReturnCode getVersion  (const fapi::Target    & i_mbaTarget,
     fapi::Target l_mbTarget;
     fapi::MBvpdKeyword l_keyword = fapi::MBVPD_KEYWORD_VM;  // try VM first
     fapi::MBvpdRecord  l_record  = fapi::MBVPD_RECORD_SPDX; // default to SPDX
-    MBvpdVMKeyword l_vmVersionBuf={};
+    MBvpdVMKeyword l_vmVersionBuf;
     uint32_t l_version = 0;
     uint32_t l_vmBufSize = sizeof(MBvpdVMKeyword); // VM keyword is of 4 bytes.
     uint16_t l_versionBuf = 0;

--- a/src/usr/hwpf/hwp/mvpd_accessors/getMBvpdMemoryDataVersion.C
+++ b/src/usr/hwpf/hwp/mvpd_accessors/getMBvpdMemoryDataVersion.C
@@ -50,7 +50,7 @@ fapi::ReturnCode getMBvpdMemoryDataVersion(
     fapi::ReturnCode l_fapirc;
     DimmType l_dimmType = ISDIMM;
     fapi::MBvpdRecord  l_record  = fapi::MBVPD_RECORD_SPDX;
-    uint32_t l_vpdMemoryDataVersion = VM_KEYWORD_DEFAULT_VALUE;   
+    MBvpdVMKeyword l_vpdMemoryDataVersion;
     uint32_t l_bufSize = sizeof(l_vpdMemoryDataVersion);
 
     FAPI_DBG("getMBvpdMemoryDataVersion: entry ");
@@ -140,8 +140,8 @@ fapi::ReturnCode getMBvpdMemoryDataVersion(
         }
                     
         // Check if the format byte in the value returned is in between valid range
-        if (( ((MBvpdVMKeyword *)(&l_vpdMemoryDataVersion))->iv_version >  VM_SUPPORTED_HIGH_VER )||
-            ( ((MBvpdVMKeyword *)(&l_vpdMemoryDataVersion))->iv_version == VM_NOT_SUPPORTED ))
+        if ((l_vpdMemoryDataVersion.iv_version >  VM_SUPPORTED_HIGH_VER )||
+            (l_vpdMemoryDataVersion.iv_version == VM_NOT_SUPPORTED ))
         {
             FAPI_ERR("getMBvpdMemoryDataVersion:"
                      " keyword data returned is invalid : %d ",

--- a/src/usr/hwpf/makefile
+++ b/src/usr/hwpf/makefile
@@ -402,18 +402,26 @@ $(call GENTARGET, ${IF_CMP_FLEX_TARGET}) : \
 	$(C2) "    FLEX       $(notdir $<)"
 	$(C1)flex -o$@ $^
 
+try = $(shell set -e; if ($(1)) >/dev/null 2>&1; \
+        then echo "$(2)"; \
+        else echo "$(3)"; fi )
+
+try-cflag = $(call try,$(1) $(2) -x c -c /dev/null -o /dev/null,$(2))
+HOSTCFLAGS:=-O3
+HOSTCFLAGS+=$(call try-cflag,$(HOST_PREFIX)g++,-std=gnu++03)
+
 $(GENDIR)/$(IF_CMP_SUBDIR)/%.host.o: \
 	    ifcompiler/%.C $(IF_COMPILER_H_FILES) \
 	    $(GENDIR)/$(IF_CMP_YACC_H_TARGET)
 	$(C2) "    CXX        $(notdir $<)"
-	$(C1)$(CCACHE) $(HOST_PREFIX)g++ -O3 $< -I ifcompiler -I $(GENDIR) \
+	$(C1)$(CCACHE) $(HOST_PREFIX)g++ $(HOSTCFLAGS) $< -I ifcompiler -I $(GENDIR) \
 			-I $(GENDIR)/$(IF_CMP_SUBDIR) \
 			-I $(ROOTPATH)/src/include/usr/hwpf/hwp -c -o $@
 
 $(GENDIR)/$(IF_CMP_YACC_C_TARGET:.c=.host.o): \
     $(GENDIR)/$(IF_CMP_YACC_C_TARGET) $(IF_COMPILER_H_FILES)
 	$(C2) "    CXX        $(notdir $<)"
-	$(C1)$(CCACHE) $(HOST_PREFIX)g++ -O3 $< -I ifcompiler -I $(GENDIR) \
+	$(C1)$(CCACHE) $(HOST_PREFIX)g++ $(HOSTCFLAGS) $< -I ifcompiler -I $(GENDIR) \
 			-I $(GENDIR)/$(IF_CMP_SUBDIR) \
 			-I $(ROOTPATH)/src/include/usr/hwpf/hwp -c -o $@
 
@@ -421,7 +429,7 @@ $(GENDIR)/$(IF_CMP_FLEX_TARGET:.c=.host.o): \
     $(GENDIR)/$(IF_CMP_FLEX_TARGET) $(IF_COMPILER_H_FILES) \
     $(GENDIR)/$(IF_CMP_YACC_H_TARGET)
 	$(C2) "    CXX        $(notdir $<)"
-	$(C1)$(CCACHE) $(HOST_PREFIX)g++ -O3 -DHOSTBOOT_COMPILE $< -I ifcompiler -I $(GENDIR) \
+	$(C1)$(CCACHE) $(HOST_PREFIX)g++ $(HOSTCFLAGS) -DHOSTBOOT_COMPILE $< -I ifcompiler -I $(GENDIR) \
 			-I $(GENDIR)/$(IF_CMP_SUBDIR) \
 			-I $(ROOTPATH)/src/include/usr/hwpf/hwp -c -o $@
 


### PR DESCRIPTION
With these fixes, it's possible to build (and boot!) a full op-build master-next build with GCC6.

None of these changes should be controversial, and GCC6 did pick up actual problems such as:
- not specifying what C++ version to build (and there are changes that matter)
- returning something from a void method
- invalid __sync ops (can't use a bool)
- relying on the address of a passed-by-reference object able to be NULL (which is not at all what anyone would expect, and it appears the compiler may have been okay to assume it could never be null)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/hostboot/62)

<!-- Reviewable:end -->
