### PR TITLE
fixup initfiles compilation options to work with gcc+make

### DIFF
--- a/src/import/chips/p9/procedures/hwp/initfiles/p9_cxa_scom.mk
+++ b/src/import/chips/p9/procedures/hwp/initfiles/p9_cxa_scom.mk
@@ -23,5 +23,6 @@
 #
 # IBM_PROLOG_END_TAG
 PROCEDURE=p9_cxa_scom
+%$(PROCEDURE).o : CFLAGS += -fno-var-tracking-assignments
 lib$(PROCEDURE)_COMMONFLAGS+=-fno-var-tracking-assignments
 $(call BUILD_PROCEDURE)

--- a/src/import/chips/p9/procedures/hwp/initfiles/p9_ddrphy_scom.mk
+++ b/src/import/chips/p9/procedures/hwp/initfiles/p9_ddrphy_scom.mk
@@ -23,5 +23,6 @@
 #
 # IBM_PROLOG_END_TAG
 PROCEDURE=p9_ddrphy_scom
+%$(PROCEDURE).o : CFLAGS += -fno-var-tracking-assignments
 lib$(PROCEDURE)_COMMONFLAGS+=-fno-var-tracking-assignments
 $(call BUILD_PROCEDURE)

--- a/src/import/chips/p9/procedures/hwp/initfiles/p9_fbc_ab_hp_scom.mk
+++ b/src/import/chips/p9/procedures/hwp/initfiles/p9_fbc_ab_hp_scom.mk
@@ -23,5 +23,6 @@
 #
 # IBM_PROLOG_END_TAG
 PROCEDURE=p9_fbc_ab_hp_scom
+%$(PROCEDURE).o : CFLAGS += -fno-var-tracking-assignments
 lib$(PROCEDURE)_COMMONFLAGS+=-fno-var-tracking-assignments
 $(call BUILD_PROCEDURE)

--- a/src/import/chips/p9/procedures/hwp/initfiles/p9_fbc_cd_hp_scom.mk
+++ b/src/import/chips/p9/procedures/hwp/initfiles/p9_fbc_cd_hp_scom.mk
@@ -23,5 +23,6 @@
 #
 # IBM_PROLOG_END_TAG
 PROCEDURE=p9_fbc_cd_hp_scom
+%$(PROCEDURE).o : CFLAGS += -fno-var-tracking-assignments
 lib$(PROCEDURE)_COMMONFLAGS+=-fno-var-tracking-assignments
 $(call BUILD_PROCEDURE)

--- a/src/import/chips/p9/procedures/hwp/initfiles/p9_fbc_ioe_dl_scom.mk
+++ b/src/import/chips/p9/procedures/hwp/initfiles/p9_fbc_ioe_dl_scom.mk
@@ -23,5 +23,6 @@
 #
 # IBM_PROLOG_END_TAG
 PROCEDURE=p9_fbc_ioe_dl_scom
+%$(PROCEDURE).o : CFLAGS += -fno-var-tracking-assignments
 lib$(PROCEDURE)_COMMONFLAGS+=-fno-var-tracking-assignments
 $(call BUILD_PROCEDURE)

--- a/src/import/chips/p9/procedures/hwp/initfiles/p9_fbc_ioe_tl_scom.mk
+++ b/src/import/chips/p9/procedures/hwp/initfiles/p9_fbc_ioe_tl_scom.mk
@@ -23,5 +23,6 @@
 #
 # IBM_PROLOG_END_TAG
 PROCEDURE=p9_fbc_ioe_tl_scom
+%$(PROCEDURE).o : CFLAGS += -fno-var-tracking-assignments
 lib$(PROCEDURE)_COMMONFLAGS+=-fno-var-tracking-assignments
 $(call BUILD_PROCEDURE)

--- a/src/import/chips/p9/procedures/hwp/initfiles/p9_fbc_ioo_dl_scom.mk
+++ b/src/import/chips/p9/procedures/hwp/initfiles/p9_fbc_ioo_dl_scom.mk
@@ -23,5 +23,6 @@
 #
 # IBM_PROLOG_END_TAG
 PROCEDURE=p9_fbc_ioo_dl_scom
+%$(PROCEDURE).o : CFLAGS += -fno-var-tracking-assignments
 lib$(PROCEDURE)_COMMONFLAGS+=-fno-var-tracking-assignments
 $(call BUILD_PROCEDURE)

--- a/src/import/chips/p9/procedures/hwp/initfiles/p9_fbc_ioo_tl_scom.mk
+++ b/src/import/chips/p9/procedures/hwp/initfiles/p9_fbc_ioo_tl_scom.mk
@@ -23,5 +23,6 @@
 #
 # IBM_PROLOG_END_TAG
 PROCEDURE=p9_fbc_ioo_tl_scom
+%$(PROCEDURE).o : CFLAGS += -fno-var-tracking-assignments
 lib$(PROCEDURE)_COMMONFLAGS+=-fno-var-tracking-assignments
 $(call BUILD_PROCEDURE)

--- a/src/import/chips/p9/procedures/hwp/initfiles/p9_fbc_no_hp_scom.mk
+++ b/src/import/chips/p9/procedures/hwp/initfiles/p9_fbc_no_hp_scom.mk
@@ -23,5 +23,6 @@
 #
 # IBM_PROLOG_END_TAG
 PROCEDURE=p9_fbc_no_hp_scom
+%$(PROCEDURE).o : CFLAGS += -fno-var-tracking-assignments
 lib$(PROCEDURE)_COMMONFLAGS+=-fno-var-tracking-assignments
 $(call BUILD_PROCEDURE)

--- a/src/import/chips/p9/procedures/hwp/initfiles/p9_int_scom.mk
+++ b/src/import/chips/p9/procedures/hwp/initfiles/p9_int_scom.mk
@@ -23,5 +23,6 @@
 #
 # IBM_PROLOG_END_TAG
 PROCEDURE=p9_int_scom
+%$(PROCEDURE).o : CFLAGS += -fno-var-tracking-assignments
 lib$(PROCEDURE)_COMMONFLAGS+=-fno-var-tracking-assignments
 $(call BUILD_PROCEDURE)

--- a/src/import/chips/p9/procedures/hwp/initfiles/p9_mca_scom.mk
+++ b/src/import/chips/p9/procedures/hwp/initfiles/p9_mca_scom.mk
@@ -23,5 +23,6 @@
 #
 # IBM_PROLOG_END_TAG
 PROCEDURE=p9_mca_scom
+%$(PROCEDURE).o : CFLAGS += -fno-var-tracking-assignments
 lib$(PROCEDURE)_COMMONFLAGS+=-fno-var-tracking-assignments
 $(call BUILD_PROCEDURE)

--- a/src/import/chips/p9/procedures/hwp/initfiles/p9_mcbist_scom.mk
+++ b/src/import/chips/p9/procedures/hwp/initfiles/p9_mcbist_scom.mk
@@ -23,5 +23,6 @@
 #
 # IBM_PROLOG_END_TAG
 PROCEDURE=p9_mcbist_scom
+%$(PROCEDURE).o : CFLAGS += -fno-var-tracking-assignments
 lib$(PROCEDURE)_COMMONFLAGS+=-fno-var-tracking-assignments
 $(call BUILD_PROCEDURE)

--- a/src/import/chips/p9/procedures/hwp/initfiles/p9_mcs_scom.mk
+++ b/src/import/chips/p9/procedures/hwp/initfiles/p9_mcs_scom.mk
@@ -23,5 +23,6 @@
 #
 # IBM_PROLOG_END_TAG
 PROCEDURE=p9_mcs_scom
+%$(PROCEDURE).o : CFLAGS += -fno-var-tracking-assignments
 lib$(PROCEDURE)_COMMONFLAGS+=-fno-var-tracking-assignments
 $(call BUILD_PROCEDURE)

--- a/src/import/chips/p9/procedures/hwp/initfiles/p9_mmu_scom.mk
+++ b/src/import/chips/p9/procedures/hwp/initfiles/p9_mmu_scom.mk
@@ -23,5 +23,6 @@
 #
 # IBM_PROLOG_END_TAG
 PROCEDURE=p9_mmu_scom
+%$(PROCEDURE).o : CFLAGS += -fno-var-tracking-assignments
 lib$(PROCEDURE)_COMMONFLAGS+=-fno-var-tracking-assignments
 $(call BUILD_PROCEDURE)

--- a/src/import/chips/p9/procedures/hwp/initfiles/p9_npu_scom.mk
+++ b/src/import/chips/p9/procedures/hwp/initfiles/p9_npu_scom.mk
@@ -23,5 +23,6 @@
 #
 # IBM_PROLOG_END_TAG
 PROCEDURE=p9_npu_scom
+%$(PROCEDURE).o : CFLAGS += -fno-var-tracking-assignments
 lib$(PROCEDURE)_COMMONFLAGS+=-fno-var-tracking-assignments
 $(call BUILD_PROCEDURE)

--- a/src/import/chips/p9/procedures/hwp/initfiles/p9_nx_scom.mk
+++ b/src/import/chips/p9/procedures/hwp/initfiles/p9_nx_scom.mk
@@ -23,5 +23,6 @@
 #
 # IBM_PROLOG_END_TAG
 PROCEDURE=p9_nx_scom
+%$(PROCEDURE).o : CFLAGS += -fno-var-tracking-assignments
 lib$(PROCEDURE)_COMMONFLAGS+=-fno-var-tracking-assignments
 $(call BUILD_PROCEDURE)

--- a/src/import/chips/p9/procedures/hwp/initfiles/p9_obus_scom.mk
+++ b/src/import/chips/p9/procedures/hwp/initfiles/p9_obus_scom.mk
@@ -23,5 +23,6 @@
 #
 # IBM_PROLOG_END_TAG
 PROCEDURE=p9_obus_scom
+%$(PROCEDURE).o : CFLAGS += -fno-var-tracking-assignments
 lib$(PROCEDURE)_COMMONFLAGS+=-fno-var-tracking-assignments
 $(call BUILD_PROCEDURE)

--- a/src/import/chips/p9/procedures/hwp/initfiles/p9_psi_scom.mk
+++ b/src/import/chips/p9/procedures/hwp/initfiles/p9_psi_scom.mk
@@ -23,5 +23,6 @@
 #
 # IBM_PROLOG_END_TAG
 PROCEDURE=p9_psi_scom
+%$(PROCEDURE).o : CFLAGS += -fno-var-tracking-assignments
 lib$(PROCEDURE)_COMMONFLAGS+=-fno-var-tracking-assignments
 $(call BUILD_PROCEDURE)

--- a/src/import/chips/p9/procedures/hwp/initfiles/p9_vas_scom.mk
+++ b/src/import/chips/p9/procedures/hwp/initfiles/p9_vas_scom.mk
@@ -23,5 +23,6 @@
 #
 # IBM_PROLOG_END_TAG
 PROCEDURE=p9_vas_scom
+%$(PROCEDURE).o : CFLAGS += -fno-var-tracking-assignments
 lib$(PROCEDURE)_COMMONFLAGS+=-fno-var-tracking-assignments
 $(call BUILD_PROCEDURE)

--- a/src/import/chips/p9/procedures/hwp/initfiles/p9_xbus_g0_scom.mk
+++ b/src/import/chips/p9/procedures/hwp/initfiles/p9_xbus_g0_scom.mk
@@ -23,5 +23,6 @@
 #
 # IBM_PROLOG_END_TAG
 PROCEDURE=p9_xbus_g0_scom
+%$(PROCEDURE).o : CFLAGS += -fno-var-tracking-assignments
 lib$(PROCEDURE)_COMMONFLAGS+=-fno-var-tracking-assignments
 $(call BUILD_PROCEDURE)

--- a/src/import/chips/p9/procedures/hwp/initfiles/p9_xbus_g1_scom.mk
+++ b/src/import/chips/p9/procedures/hwp/initfiles/p9_xbus_g1_scom.mk
@@ -23,5 +23,6 @@
 #
 # IBM_PROLOG_END_TAG
 PROCEDURE=p9_xbus_g1_scom
+%$(PROCEDURE).o : CFLAGS += -fno-var-tracking-assignments
 lib$(PROCEDURE)_COMMONFLAGS+=-fno-var-tracking-assignments
 $(call BUILD_PROCEDURE)


### PR DESCRIPTION
Adding -fno-var-tracking-assignments speeds up the compilation
of these files significantly.  The existing lib*_COMMONFLAGS directive
doesn't seem to work with the makefile rules (maybe for some other build
system).

Change-Id: Idd6697ff6dc33d95f1b568b474bf2208f133d34a
Signed-off-by: Robert Lippert <rlippert@google.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/hostboot/76)
<!-- Reviewable:end -->
