### PR TITLE
sbe: flush PNOR sections after customization to free up memory

### DIFF
--- a/src/usr/sbe/sbe_update.C
+++ b/src/usr/sbe/sbe_update.C
@@ -3893,6 +3893,8 @@ namespace SBE
                 break;
             }
 
+            PNOR::flush( PNOR::SBE_IPL );
+
         }while(0);
 
 


### PR DESCRIPTION
After customizing the PNOR data is no longer needed but remains
resident in memory because the customization step overwrites
some of the PNOR data each time which marks it as dirty.

This change forces the pages to be released so that the memory
is free for other allocations without needing to castout or evict
the dirty pages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/hostboot/78)
<!-- Reviewable:end -->
