### PR TITLE
sbe: optionally enable SEEPROM write protect after update phase

### DIFF
--- a/src/usr/sbe/HBconfig
+++ b/src/usr/sbe/HBconfig
@@ -40,3 +40,8 @@ config NO_SBE_UPDATES
     default n
     help
         Don't update the SBE SEEPROMs at all.
+
+config SBE_UPDATE_LOCK
+    default y
+    help
+        Lock the SEEPROMs after updating

--- a/src/usr/sbe/sbe_update.C
+++ b/src/usr/sbe/sbe_update.C
@@ -452,6 +452,22 @@ namespace SBE
                 }
 #endif
 
+                /**********************************************/
+                /*   Lock the SBE flash after the update      */
+                /**********************************************/
+#ifdef CONFIG_SBE_UPDATE_LOCK
+                const std::vector<SECUREBOOT::ProcSecurity> SUL {
+                    SECUREBOOT::ProcSecurity::SULBit,
+                };
+                err = SECUREBOOT::setSecuritySwitchBits(SUL, sbeState.target);
+                if ( err  != NULL ) {
+                    TRACFCOMP( g_trac_sbe,
+                               ERR_MRK"updateProcessorSbeSeeproms(): "
+                              "Failed to lock SBE" );
+                    errlCommit( err, SBE_COMP_ID );
+                }
+#endif
+
                 // Push this sbeState onto the vector
                 sbeStates_vector.push_back(sbeState);
 


### PR DESCRIPTION
Adds a config option and code to control setting the trusted SEEPROM
write protect bit that prevents further writes to the SBE EEPROMs until
the processor is reset.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/hostboot/79)
<!-- Reviewable:end -->
