### PR TITLE
i2c: only send 1 master stop in FORCE_UNLOCK reset mode

### DIFF
--- a/src/usr/i2c/i2c.C
+++ b/src/usr/i2c/i2c.C
@@ -2723,12 +2723,13 @@ errlHndl_t i2cReset ( TARGETING::Target * i_target,
                 // So just commit the log here and let the function continue.
                 errlCommit( err, I2C_COMP_ID );
             }
-        }
+        } else {
 
-        // Part of doing the I2C Master reset is also sending a stop
-        // command to the slave device.
-        err = i2cSendSlaveStop( i_target,
-                                i_args );
+            // Part of doing the I2C Master reset is also sending a stop
+            // command to the slave device.
+            err = i2cSendSlaveStop( i_target,
+                                    i_args );
+        }
 
         if( err )
         {


### PR DESCRIPTION
The existing code path would send 2 master stops, one in
i2cForceResetAndUnlock() and another in i2cSendSlaveStop().

The one in i2cSendSlaveStop() can cause IPL failures if the
VSPD voltage is not online for a centaur I2C port because
it requires checking that the I2C bus is "free" (pulled up)
before reporting success.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/hostboot/81)
<!-- Reviewable:end -->
