### PR TITLE
kernel: consider writable/clean pages as evictable

### DIFF
--- a/src/kernel/block.C
+++ b/src/kernel/block.C
@@ -404,7 +404,7 @@ void Block::castOutPages(uint64_t i_type)
                 //else printk("r");
                 //printk("%d",(int)pte->getLRU());
 
-                if(pte->isWritable())
+                if(pte->isWritable() && pte->isDirty())
                 {
                     if(pte->getLRU() > rw_constraint && pte->isWriteTracked())
                     {


### PR DESCRIPTION
The PnorRP maps "readonly" PNOR sections as WRITABLE so that
procedures can scribble on the memory if necessary.  But this
causes the kernel to never cast out these (usually) read-only
pages and eventually run out of memory.

To fix this only consider a writable+dirty page as actually
unevictable, and treat a writable+clean page as readonly similarly
to other logic in this file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/hostboot/86)
<!-- Reviewable:end -->
