### PR TITLE
buildpnor: Add FMAP support

### DIFF
--- a/src/build/buildpnor/buildpnor.pl
+++ b/src/build/buildpnor/buildpnor.pl
@@ -7,6 +7,7 @@
 # OpenPOWER HostBoot Project
 #
 # Contributors Listed Below - COPYRIGHT 2012,2017
+# [+] Google Inc.
 # [+] International Business Machines Corp.
 #
 #
@@ -31,6 +32,7 @@
 # numbers cannot be over 32 bits
 
 use strict;
+use bytes;
 use Data::Dumper;
 use File::Basename;
 use Cwd qw(abs_path);
@@ -56,10 +58,30 @@ my %SideOptions = (
         B => "B",
         sideless => "sideless",
     );
+my %bbinfo = (
+        "board" => "no-such-board",
+        "version" => "0.0.0",
+        "lock" => "dev",
+    );
+$bbinfo{timestamp} = gmtime;
 
 if ($#ARGV < 0) {
     usage();
     exit;
+}
+
+#Parse environment variables
+if (exists $ENV{BBINFO_BOARD}) {
+    $bbinfo{board} = $ENV{BBINFO_BOARD}
+}
+if (exists $ENV{BBINFO_VERSION}) {
+    $bbinfo{version} = $ENV{BBINFO_VERSION}
+}
+if (exists $ENV{BBINFO_LOCK}) {
+    $bbinfo{lock} = $ENV{BBINFO_LOCK}
+}
+if (exists $ENV{BBINFO_TIMESTAMP}) {
+    $bbinfo{timestamp} = $ENV{BBINFO_TIMESTAMP}
 }
 
 #Parse the commandline args
@@ -95,10 +117,22 @@ for (my $i=0; $i < $#ARGV + 1; $i++)
     elsif($ARGV[$i] =~ /--test/) {
         $testRun = 1;
     }
+    elsif($ARGV[$i] =~ /--bbinfoBoard/) {
+        $bbinfo{board} = $ARGV[++$i];
+    }
+    elsif($ARGV[$i] =~ /--bbinfoVersion/) {
+        $bbinfo{version} = $ARGV[++$i];
+    }
+    elsif($ARGV[$i] =~ /--bbinfoLock/) {
+        $bbinfo{lock} = $ARGV[++$i];
+    }
+    elsif($ARGV[$i] =~ /--bbinfoTimestamp/) {
+        $bbinfo{timestamp} = $ARGV[++$i];
+    }
     else {
         traceErr("Unrecognized Input: $ARGV[$i]");
         exit 1;
-	#Error!!
+    #Error!!
     }
 }
 
@@ -154,6 +188,10 @@ foreach my $sideId ( keys %{$pnorLayout{metadata}{sides}} )
 
     fillPnorImage($pnorBinName, \%pnorLayout, \%binFiles, $sideId, $tocOffset);
 }
+
+# Potentially add FMAP Section
+my $rc = addFMAPToPnorImage($pnorBinName, \%pnorLayout, \%bbinfo, \%PhysicalOffsets);
+die "ERROR: Call to addFMAPToPnorImage() failed. Aborting!" if($rc);
 
 exit 0;
 
@@ -483,6 +521,84 @@ sub fillPnorImage
      }
 }
 
+#################################################################################
+# addFMAPToPnorImage - Add FMAP structure (https://github.com/dhendrix/flashmap).
+#################################################################################
+sub addFMAPToPnorImage
+{
+    my ($i_pnorBinName, $i_pnorLayoutRef, $bbinfoRef, $i_physicalOffsetsRef) = @_;
+    my $imageSize = $$i_pnorLayoutRef{metadata}{imageSize};
+
+    trace(1, "Testing for existence of FMAP section");
+    my %i_eyecatches = %{$$i_physicalOffsetsRef{side}{(keys %{$$i_pnorLayoutRef{metadata}{sides}})[0]}{eyecatch}};
+    if (not exists $i_eyecatches{FMAP})
+    {
+        return 0;
+    }
+	my $fmapOffset = $i_eyecatches{FMAP};
+    trace(1, "Adding fmap to image");
+
+    my %sectionHash = %{$$i_pnorLayoutRef{sections}};
+    my $key;
+    my $numSections = keys(%sectionHash);
+
+    if ($sectionHash{$fmapOffset}{side} ne "sideless")
+    {
+        trace(0, "FMAP section must be sideless");
+        return 1;
+    }
+
+    my $fmap = pack("a8ccVVVa32v", "__FMAP__", 1, 2, 0, 0, $imageSize, $$bbinfoRef{board}, $numSections);
+    my $endOfMap = 0;
+    for $key ( sort {$a<=> $b} keys %sectionHash)
+    {
+        my $description = $sectionHash{$key}{eyeCatch};
+        my $physicalOffset = $sectionHash{$key}{physicalOffset};
+        my $physicalRegionSize = $sectionHash{$key}{physicalRegionSize};
+        my $flags = ($sectionHash{$key}{readOnly} eq "yes" ? 1 : 0);
+        trace(3, "flags:$flags writeable:$sectionHash{$key}{readOnly}");
+
+        $endOfMap = $physicalOffset + $physicalRegionSize;
+        $fmap .= pack("VVa32v", $physicalOffset, $physicalRegionSize, $description, $flags);
+    }
+
+    # Align hash structure on 16 byte boundary
+    my $align = bytes::length($fmap) & 15;
+    if ($align != 0)
+    {
+        $fmap .= "\0" x (16 - $align);
+    }
+
+    $fmap .= pack("a8ccva32a128", "__HASH__", 1, 0, $numSections, "SHA512", "\0");
+    for $key ( sort {$a<=> $b} keys %sectionHash)
+    {
+        my $description = $sectionHash{$key}{eyeCatch};
+        my $physicalOffset = $sectionHash{$key}{physicalOffset};
+        my $physicalRegionSize = $sectionHash{$key}{physicalRegionSize};
+        $fmap .= pack("VVa32a128", $physicalOffset, $physicalRegionSize, $description, "\0");
+    }
+
+    # Align BBINFO on a 16 byte boundary
+    my $align = bytes::length($fmap) & 15;
+    if ($align != 0)
+    {
+        $fmap .= "\0" x (16 - $align);
+    }
+    $fmap .= "BBINFO__\0";
+    $fmap .= "board:$$bbinfoRef{board}\0";
+    $fmap .= "version:$$bbinfoRef{version}\0";
+    $fmap .= "lock:$$bbinfoRef{lock}\0";
+    $fmap .= "timestamp:$$bbinfoRef{timestamp}\0\0";
+
+    my $maxSize = $sectionHash{$fmapOffset}{physicalRegionSize};
+    my $fmapSize = bytes::length($fmap);
+    die "FMAP of size=$fmapSize is too large for pnor allocation area of $maxSize" if ($fmapSize > $maxSize);
+    open(PIPE, " | dd of=$i_pnorBinName conv=notrunc bs=1 seek=$fmapOffset count=$fmapSize >& /dev/null");
+    print(PIPE $fmap);
+    close(PIPE);
+    return 0;
+}
+
 ################################################################################
 # saveInputFile - save inputfile name into binFiles array
 ################################################################################
@@ -605,6 +721,10 @@ print <<"ENDUSAGE";
     --fpartCmd          invoke string for executing the fpart tool
     --fcpCmd            invoke string for executing the fcp tool
     --test              Output test-only sections.
+    --bbinfoBoard       board name for BBINFO structure, only needed if you have an FMAP.
+    --bbinfoVersion     version string for BBINFO structure, only needed if you have an FMAP.
+    --bbinfoLock        lock string for BBINFO structure, only needed if you have an FMAP.
+    --bbinfoTimestamp   timestamp for BBINFO structure, only needed if you have an FMAP.
 
   Current Limitations:
       --TOC Records must be 4 or 8 bytes in length


### PR DESCRIPTION
This commit adds the ability to generate FMAP partitions in the pnor image, alongside the current partition table. FMAP tables are only added if the fmapOffset and fmapSize attributes are present in the metadata section of the pnor xml schema. You can check the validity of the FMAP table by using a tool like

https://github.com/dhendrix/flashmap

```
fmap_decode <pnor file>
```

Assuming that you modify the defaultPnorLayout_64.xml file in the pnor schemas:
```
diff --git a/p9Layouts/defaultPnorLayout_64.xml b/p9Layouts/defaultPnorLayout_64.xml
index ba0fe8c..6d97530 100644
--- a/p9Layouts/defaultPnorLayout_64.xml
+++ b/p9Layouts/defaultPnorLayout_64.xml
@@ -27,6 +27,8 @@ Layout Description
     <imageSize>    -> Size of PNOR image in bytes.
     <blockSize>    -> size of erase blocks in bytes.
     <tocSize>      -> size of each partition table
+    <fmapOffset>   -> offset for the beginning of the flashmap partition table
+    <fmapSize>     -> size of the flashmap partition table
     <!- TODO:RTC:123734 - remove side offsets once hwsv implements new layout ->
     <sideAOffset>  -> Location of Side A Partition Table
     <sideBOffset>  -> Location of Side B Partition Table
@@ -66,7 +68,9 @@ Layout Description
         <imageSize>0x4000000</imageSize>
         <chipSize>0x4000000</chipSize>
         <blockSize>0x1000</blockSize>
-        <tocSize>0x8000</tocSize>
+        <tocSize>0x4000</tocSize>
+        <fmapOffset>0x4000</fmapOffset>
+        <fmapSize>0x4000</fmapSize>
         <arrangement>A-D-B</arrangement>
         <side>
             <id>A</id>
```

This should give you a result like the following for the default p9 schema:
```
fmap_signature="0x5f5f464d41505f5f" fmap_ver_major="1" fmap_ver_minor="2" fmap_base="0x0000000000000000" fmap_size="0x4000000" fmap_name="zaius" fmap_nareas="24"
area_offset="0x00008000" area_size="0x00090000" area_name="HBB" area_flags_raw="0x00" area_flags=""
area_offset="0x00098000" area_size="0x00024000" area_name="HBEL" area_flags_raw="0x00" area_flags=""
area_offset="0x000bc000" area_size="0x00005000" area_name="GUARD" area_flags_raw="0x00" area_flags=""
area_offset="0x000c1000" area_size="0x00120000" area_name="HBD" area_flags_raw="0x00" area_flags=""
area_offset="0x001e1000" area_size="0x00048000" area_name="DJVPD" area_flags_raw="0x00" area_flags=""
area_offset="0x00229000" area_size="0x00090000" area_name="MVPD" area_flags_raw="0x00" area_flags=""
area_offset="0x002b9000" area_size="0x00048000" area_name="CVPD" area_flags_raw="0x00" area_flags=""
area_offset="0x00301000" area_size="0x00c60000" area_name="HBI" area_flags_raw="0x00" area_flags=""
area_offset="0x00f61000" area_size="0x00048000" area_name="SBE" area_flags_raw="0x00" area_flags=""
area_offset="0x00fa9000" area_size="0x00120000" area_name="HCODE" area_flags_raw="0x00" area_flags=""
area_offset="0x010c9000" area_size="0x00480000" area_name="HBRT" area_flags_raw="0x00" area_flags=""
area_offset="0x01549000" area_size="0x00100000" area_name="PAYLOAD" area_flags_raw="0x00" area_flags=""
area_offset="0x01649000" area_size="0x00f00000" area_name="BOOTKERNEL" area_flags_raw="0x00" area_flags=""
area_offset="0x02549000" area_size="0x00090000" area_name="NVRAM" area_flags_raw="0x00" area_flags=""
area_offset="0x025d9000" area_size="0x00120000" area_name="OCC" area_flags_raw="0x00" area_flags=""
area_offset="0x026f9000" area_size="0x00003000" area_name="FIRDATA" area_flags_raw="0x00" area_flags=""
area_offset="0x026fc000" area_size="0x00024000" area_name="CAPP" area_flags_raw="0x00" area_flags=""
area_offset="0x02720000" area_size="0x00024000" area_name="SECBOOT" area_flags_raw="0x00" area_flags=""
area_offset="0x02744000" area_size="0x00009000" area_name="BMC_INV" area_flags_raw="0x00" area_flags=""
area_offset="0x0274d000" area_size="0x00006000" area_name="HBBL" area_flags_raw="0x00" area_flags=""
area_offset="0x02753000" area_size="0x00008000" area_name="ATTR_TMP" area_flags_raw="0x00" area_flags=""
area_offset="0x0275b000" area_size="0x00008000" area_name="ATTR_PERM" area_flags_raw="0x00" area_flags=""
area_offset="0x02763000" area_size="0x00001000" area_name="VERSION" area_flags_raw="0x00" area_flags=""
area_offset="0x02764000" area_size="0x00040000" area_name="IMA_CATALOG" area_flags_raw="0x00" area_flags=""
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/hostboot/92)
<!-- Reviewable:end -->
