### PR TITLE
[RFC] Fixes required to build P9 STOP API with skiboot

### DIFF
--- a/src/import/chips/p9/procedures/hwp/lib/p9_stop_util.H
+++ b/src/import/chips/p9/procedures/hwp/lib/p9_stop_util.H
@@ -49,8 +49,10 @@
 // *HWP Level       :  2
 // *HWP Consumed by :  HB:HYP
 #ifndef __PPE_PLAT
+#ifdef __cplusplus
 namespace stopImageSection
 {
+#endif
 #endif  //__PPE_PLAT
 /**
  * @brief  helper function to swizzle given input data
@@ -131,9 +133,10 @@ StopReturnCode_t getCoreAndThread( void* const i_pStopImage,
                                    const uint64_t i_pir,
                                    uint32_t* o_coreId,
                                    uint32_t* o_threadId );
-
+#ifdef __cplusplus
 } // namespace stopImageSection ends
 
+#endif
 #endif //__PPE_PLAT
 #endif
 

--- a/src/import/chips/p9/procedures/hwp/lib/p9_stop_util.H
+++ b/src/import/chips/p9/procedures/hwp/lib/p9_stop_util.H
@@ -27,6 +27,8 @@
 
 #ifdef _AIX
     #define __BYTE_ORDER __BIG_ENDIAN
+#elif __SKIBOOT__
+	#include <skiboot.h>
 #else
     #include <endian.h>
 #endif

--- a/src/import/chips/p9/procedures/utils/stopreg/p9_stop_api.C
+++ b/src/import/chips/p9/procedures/utils/stopreg/p9_stop_api.C
@@ -83,7 +83,7 @@ const uint32_t MAX_SPR_SUPPORTED =
  * @note    for register of scope core, function shall force io_threadId to
  *          zero.
  */
-StopReturnCode_t validateSprImageInputs( void*   const i_pImage,
+static StopReturnCode_t validateSprImageInputs( void*   const i_pImage,
         const CpuReg_t i_regId,
         const uint32_t  i_coreId,
         uint32_t*     i_pThreadId,
@@ -180,7 +180,7 @@ StopReturnCode_t validateSprImageInputs( void*   const i_pImage,
  * @param[in]   i_data  16 bit immediate data
  * @return  returns 32 bit number representing ori instruction.
  */
-uint32_t getOriInstruction( const uint16_t i_Rs, const uint16_t i_Ra,
+static uint32_t getOriInstruction( const uint16_t i_Rs, const uint16_t i_Ra,
                             const uint16_t i_data )
 {
     uint32_t oriInstOpcode = 0;
@@ -198,7 +198,7 @@ uint32_t getOriInstruction( const uint16_t i_Rs, const uint16_t i_Ra,
 /**
  * @brief generates 32 bit key used for SPR lookup in core section.
  */
-uint32_t genKeyForSprLookup( const CpuReg_t i_regId )
+static uint32_t genKeyForSprLookup( const CpuReg_t i_regId )
 {
     return getOriInstruction( 0, 0, (uint16_t) i_regId );
 }
@@ -212,7 +212,7 @@ uint32_t genKeyForSprLookup( const CpuReg_t i_regId )
  * @param[in] i_Rb source register number for xor operation
  * @return returns 32 bit number representing xor  immediate instruction.
  */
-uint32_t getXorInstruction( const uint16_t i_Ra, const uint16_t i_Rs,
+static uint32_t getXorInstruction( const uint16_t i_Ra, const uint16_t i_Rs,
                             const uint16_t i_Rb )
 {
     uint32_t xorRegInstOpcode;
@@ -234,7 +234,7 @@ uint32_t getXorInstruction( const uint16_t i_Ra, const uint16_t i_Rs,
  * @param[in] i_data    16 bit immediate data
  * @return returns 32 bit number representing oris  immediate instruction.
  */
-uint32_t getOrisInstruction( const uint16_t i_Rs, const uint16_t i_Ra,
+static uint32_t getOrisInstruction( const uint16_t i_Rs, const uint16_t i_Ra,
                              const uint16_t i_data )
 {
     uint32_t orisInstOpcode;
@@ -254,7 +254,7 @@ uint32_t getOrisInstruction( const uint16_t i_Rs, const uint16_t i_Ra,
  * @param[in] i_Spr represents spr where data is to be moved.
  * @return returns 32 bit number representing mtspr instruction.
  */
-uint32_t getMtsprInstruction( const uint16_t i_Rs, const uint16_t i_Spr )
+static uint32_t getMtsprInstruction( const uint16_t i_Rs, const uint16_t i_Spr )
 {
     uint32_t mtsprInstOpcode = 0;
     uint32_t temp = (( i_Spr & 0x03FF ) << 11);
@@ -276,7 +276,7 @@ uint32_t getMtsprInstruction( const uint16_t i_Rs, const uint16_t i_Spr )
  * @param[in] i_me      bit position up to which mask should be 1.
  * @return returns 32 bit number representing rldicr instruction.
  */
-uint32_t getRldicrInstruction( const uint16_t i_Ra, const uint16_t i_Rs,
+static uint32_t getRldicrInstruction( const uint16_t i_Ra, const uint16_t i_Rs,
                                const uint16_t i_sh, uint16_t i_me )
 {
     uint32_t rldicrInstOpcode = 0;
@@ -297,7 +297,7 @@ uint32_t getRldicrInstruction( const uint16_t i_Ra, const uint16_t i_Rs,
  * @return  returns 32 bit number representing mtmsrd instruction.
  * @note    moves contents of register i_Rs to MSR register.
  */
-uint32_t getMtmsrdInstruction( const uint16_t i_Rs )
+static uint32_t getMtmsrdInstruction( const uint16_t i_Rs )
 {
     uint32_t mtmsrdInstOpcode = 0;
     mtmsrdInstOpcode = 0;
@@ -320,7 +320,7 @@ uint32_t getMtmsrdInstruction( const uint16_t i_Rs )
  * @return      STOP_SAVE_SUCCESS if entry is found, STOP_SAVE_FAIL in case of
  *              an error.
  */
-StopReturnCode_t lookUpSprInImage( uint32_t* i_pThreadSectLoc,
+static StopReturnCode_t lookUpSprInImage( uint32_t* i_pThreadSectLoc,
                                    const uint32_t i_lookUpKey,
                                    const bool i_isCoreReg,
                                    void** io_pSprEntryLoc )
@@ -371,7 +371,7 @@ StopReturnCode_t lookUpSprInImage( uint32_t* i_pThreadSectLoc,
  * @param[in] i_regData     data needs to be written to SPR entry.
  * @return    STOP_SAVE_SUCCESS if update works, STOP_SAVE_FAIL otherwise.
  */
-StopReturnCode_t updateSprEntryInImage( uint32_t* i_pSprEntryLocation,
+static StopReturnCode_t updateSprEntryInImage( uint32_t* i_pSprEntryLocation,
                                         const CpuReg_t i_regId,
                                         const uint64_t i_regData )
 {
@@ -591,7 +591,7 @@ StopReturnCode_t p9_stop_save_cpureg(  void* const i_pImage,
  * @note        Function does not validate that the given SCOM address really
  *              belongs to the given section.
  */
-StopReturnCode_t validateScomImageInputs( void* const i_pImage,
+static StopReturnCode_t validateScomImageInputs( void* const i_pImage,
         const uint32_t i_scomAddress,
         const uint8_t i_chipletId,
         const ScomOperation_t i_operation,
@@ -684,7 +684,7 @@ StopReturnCode_t validateScomImageInputs( void* const i_pImage,
  * @return      STOP_SAVE_SUCCESS if existing entry is updated, STOP_SAVE_FAIL
  *              otherwise.
  */
-StopReturnCode_t editScomEntry( uint32_t i_scomAddr, uint64_t i_scomData,
+static StopReturnCode_t editScomEntry( uint32_t i_scomAddr, uint64_t i_scomData,
                                 ScomEntry_t* i_pEntryLocation,
                                 uint32_t i_operation )
 {
@@ -745,7 +745,7 @@ StopReturnCode_t editScomEntry( uint32_t i_scomAddr, uint64_t i_scomData,
  *              place of NOP, at the end of table or as first entry of the cache
  *              sub-section(L2, L3 or EQ ).
  */
-StopReturnCode_t updateScomEntry( uint32_t i_scomAddr, uint64_t i_scomData,
+static StopReturnCode_t updateScomEntry( uint32_t i_scomAddr, uint64_t i_scomData,
                                   ScomEntry_t* i_scomEntry   )
 {
     StopReturnCode_t l_rc = STOP_SAVE_SUCCESS;

--- a/src/import/chips/p9/procedures/utils/stopreg/p9_stop_api.C
+++ b/src/import/chips/p9/procedures/utils/stopreg/p9_stop_api.C
@@ -325,8 +325,8 @@ static StopReturnCode_t lookUpSprInImage( uint32_t* i_pThreadSectLoc,
                                    void** io_pSprEntryLoc )
 {
     StopReturnCode_t l_rc = STOP_SAVE_FAIL;
-    uint32_t temp = i_isCoreReg ? uint32_t(CORE_RESTORE_CORE_AREA_SIZE) :
-                    uint32_t(CORE_RESTORE_THREAD_AREA_SIZE);
+    uint32_t temp = i_isCoreReg ? (uint32_t)(CORE_RESTORE_CORE_AREA_SIZE) :
+                    (uint32_t)(CORE_RESTORE_THREAD_AREA_SIZE);
     uint32_t* i_threadSectEnd = i_pThreadSectLoc + temp;
     uint32_t bctr_inst = SWIZZLE_4_BYTE(BLR_INST);
     *io_pSprEntryLoc = NULL;

--- a/src/import/chips/p9/procedures/utils/stopreg/p9_stop_api.C
+++ b/src/import/chips/p9/procedures/utils/stopreg/p9_stop_api.C
@@ -89,6 +89,7 @@ static StopReturnCode_t validateSprImageInputs( void*   const i_pImage,
         uint32_t*     i_pThreadId,
         bool* i_pThreadLevelReg )
 {
+    uint32_t index = 0;
     StopReturnCode_t l_rc = STOP_SAVE_SUCCESS;
     bool sprSupported = false;
     *i_pThreadLevelReg = false;
@@ -133,8 +134,6 @@ static StopReturnCode_t validateSprImageInputs( void*   const i_pImage,
             MY_ERR( "invalid thread " );
             break;
         }
-
-        uint32_t index = 0;
 
         for( index = 0; index < MAX_SPR_SUPPORTED; ++index )
         {
@@ -783,6 +782,16 @@ StopReturnCode_t p9_stop_save_scom( void* const   i_pImage,
     uint32_t entryLimit = 0;
     uint8_t chipletId = 0;
 
+    uint32_t nopInst;
+    ScomEntry_t* pEntryLocation = NULL;
+    ScomEntry_t* pNopLocation = NULL;
+    ScomEntry_t* pTableEndLocationtable = NULL;
+    uint32_t swizzleAddr;
+    uint64_t swizzleData;
+    uint32_t swizzleAttn;
+    uint32_t swizzleEntry;
+    uint32_t index = 0;
+    uint32_t swizzleBlr = SWIZZLE_4_BYTE(BLR_INST);
     do
     {
         chipletId = i_scomAddress >> 24;
@@ -865,17 +874,11 @@ StopReturnCode_t p9_stop_save_scom( void* const   i_pImage,
             break;
         }
 
-        uint32_t nopInst = getOriInstruction( 0, 0, 0 );
-
-        ScomEntry_t* pEntryLocation = NULL;
-        ScomEntry_t* pNopLocation = NULL;
-        ScomEntry_t* pTableEndLocationtable = NULL;
-        uint32_t swizzleAddr = SWIZZLE_4_BYTE(i_scomAddress);
-        uint64_t swizzleData = SWIZZLE_8_BYTE(i_scomData);
-        uint32_t swizzleAttn = SWIZZLE_4_BYTE(ATTN_OPCODE);
-        uint32_t swizzleEntry = SWIZZLE_4_BYTE(SCOM_ENTRY_START);
-        uint32_t index = 0;
-        uint32_t swizzleBlr = SWIZZLE_4_BYTE(BLR_INST);
+	nopInst = getOriInstruction( 0, 0, 0 );
+	swizzleAddr = SWIZZLE_4_BYTE(i_scomAddress);
+	swizzleData = SWIZZLE_8_BYTE(i_scomData);
+	swizzleAttn = SWIZZLE_4_BYTE(ATTN_OPCODE);
+	swizzleEntry = SWIZZLE_4_BYTE(SCOM_ENTRY_START);
 
         for( index = 0; index < entryLimit; ++index )
         {

--- a/src/import/chips/p9/procedures/utils/stopreg/p9_stop_api.C
+++ b/src/import/chips/p9/procedures/utils/stopreg/p9_stop_api.C
@@ -289,7 +289,7 @@ static uint32_t getRldicrInstruction( const uint16_t i_Ra, const uint16_t i_Rs,
 }
 
 //-----------------------------------------------------------------------------
-
+#if 0
 /**
  * @brief generates instruction for mtmsrd instruction.
  * @param[in]   i_Rs      source register number
@@ -305,7 +305,7 @@ static uint32_t getMtmsrdInstruction( const uint16_t i_Rs )
 
     return SWIZZLE_4_BYTE(mtmsrdInstOpcode);
 }
-
+#endif
 //-----------------------------------------------------------------------------
 
 /**

--- a/src/import/chips/p9/procedures/utils/stopreg/p9_stop_api.H
+++ b/src/import/chips/p9/procedures/utils/stopreg/p9_stop_api.H
@@ -27,6 +27,10 @@
 
 #include <stdint.h>
 
+#ifdef __SKIBOOT__
+   #include <skiboot.h>
+#endif
+
 ///
 /// @file   p9_stop_api.H
 /// @brief  describes STOP API which  create/manipulate STOP image.

--- a/src/import/chips/p9/procedures/utils/stopreg/p9_stop_data_struct.H
+++ b/src/import/chips/p9/procedures/utils/stopreg/p9_stop_data_struct.H
@@ -41,6 +41,10 @@
 
 #include "p9_hcd_memmap_base.H"
 
+#ifdef __SKIBOOT__
+    #include <skiboot.h>
+#endif
+
 #ifdef __FAPI_2_
     #include <fapi2.H>
 #endif

--- a/src/import/chips/p9/procedures/utils/stopreg/p9_stop_util.C
+++ b/src/import/chips/p9/procedures/utils/stopreg/p9_stop_util.C
@@ -48,7 +48,7 @@ namespace stopImageSection
  * @param   o_fusedMode  points to fuse mode information.
  * @return  STOP_SAVE_SUCCESS if functions succeeds, error code otherwise.
  */
-StopReturnCode_t  isFusedMode( void* const i_pImage, bool* o_fusedMode )
+static StopReturnCode_t  isFusedMode( void* const i_pImage, bool* o_fusedMode )
 {
     *o_fusedMode = false;
     StopReturnCode_t l_rc = STOP_SAVE_SUCCESS;

--- a/src/import/chips/p9/procedures/utils/stopreg/p9_stop_util.C
+++ b/src/import/chips/p9/procedures/utils/stopreg/p9_stop_util.C
@@ -50,11 +50,13 @@ namespace stopImageSection
  */
 static StopReturnCode_t  isFusedMode( void* const i_pImage, bool* o_fusedMode )
 {
-    *o_fusedMode = false;
     StopReturnCode_t l_rc = STOP_SAVE_SUCCESS;
+    *o_fusedMode = false;
 
     do
     {
+        HomerSection_t* pHomerDesc = ( HomerSection_t* ) i_pImage;
+        HomerImgDesc_t* pHomer =  (HomerImgDesc_t*)( pHomerDesc->interrruptHandler );
         if( !i_pImage )
         {
             MY_ERR( "invalid pointer to HOMER image");
@@ -62,8 +64,6 @@ static StopReturnCode_t  isFusedMode( void* const i_pImage, bool* o_fusedMode )
             break;
         }
 
-        HomerSection_t* pHomerDesc = ( HomerSection_t* ) i_pImage;
-        HomerImgDesc_t* pHomer =  (HomerImgDesc_t*)( pHomerDesc->interrruptHandler );
 
         if( SWIZZLE_8_BYTE(CPMR_MAGIC_NUMBER) != pHomer->cpmrMagicWord )
         {


### PR DESCRIPTION
This pull request contains code changes which are needed to build P9 STOP API for skiboot/opal firmware. 

- Fixes  are mostly around detecting skiboot environment using  \_\_SKIBOOT\_\_ and including files required for the build.

- Fixes related to using C compiler instead of C++

- Fixes related to mixed code and declaration and other compiler error/warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/hostboot/100)
<!-- Reviewable:end -->
