### PR TITLE
bootloader: Remove hbi_ImageId

### DIFF
--- a/src/bootloader/bl_start.S
+++ b/src/bootloader/bl_start.S
@@ -399,11 +399,6 @@ switchToHBB:
 kernel_other_thread_spinlock:
     .space 8
 
-    .balign 16
-.global hbi_ImageId
-hbi_ImageId:
-    .space 128
-
 .global bootloader_end_address
 bootloader_end_address:
     .quad HBBL_END_ADDRESS

--- a/src/build/tools/addimgid
+++ b/src/build/tools/addimgid
@@ -35,7 +35,12 @@ my $imgBase = $img;
 $imgBase =~ s/.*\///;
 
 my $PREFIX = $ENV{'CROSS_PREFIX'};
-my $address = hex `${PREFIX}nm $src -C | grep $imageIdSym | colrm 17`;
+my $addressStr = `${PREFIX}nm $src -C | grep $imageIdSym | colrm 17`;
+if ($addressStr eq '')
+{
+    exit 0;
+}
+my $address = hex $addressStr;
 my $imageId = $ENV{'HOSTBOOT_VERSION'};
 if ($imageId eq '')
 {


### PR DESCRIPTION
None of the bootloader code references the hbi_ImageId but it is
included anyway. If the version string is changed in the build sequence
this results in a new hbbi.bin image. When booting with this new image,
an SBE update will be triggered since the hbbl.bin is different than the
one in the on chip SBE.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/hostboot/102)
<!-- Reviewable:end -->
