### PR TITLE
Hostboot send istep progress to LPC debug port 0x80

### DIFF
--- a/src/usr/diag/prdf/common/plat/p9/p9_nimbus.rule
+++ b/src/usr/diag/prdf/common/plat/p9/p9_nimbus.rule
@@ -6384,12 +6384,12 @@ group gPBAMFIR filter singlebit, cs_root_cause
     /** PBAMFIR[3]
      *  action0_for_OPB_error
      */
-    (rPBAMFIR, bit(3)) ? self_th_1;
+    (rPBAMFIR, bit(3)) ? defaultMaskedError;
 
     /** PBAMFIR[4]
      *  action0_for_OPB_timeout
      */
-    (rPBAMFIR, bit(4)) ? self_th_32perDay;
+    (rPBAMFIR, bit(4)) ? defaultMaskedError;
 
     /** PBAMFIR[5]
      *  action0_for_OPB_master_hang_timeout

--- a/src/usr/initservice/istepdispatcher/HBconfig
+++ b/src/usr/initservice/istepdispatcher/HBconfig
@@ -13,4 +13,7 @@ config SIO_ISTEP_CONTROL
     help
         Allows istep control via SIO scratch registers.
         Typical usage is via mailbox (scom) scratch registers.
-
+config ISTEP_LPC_PORT80_DEBUG
+    default n
+    help
+        Writes ISTEP progress to LPC port 80h.

--- a/src/usr/initservice/istepdispatcher/istepdispatcher.C
+++ b/src/usr/initservice/istepdispatcher/istepdispatcher.C
@@ -65,6 +65,7 @@
 #include <console/consoleif.H>
 #include <isteps/hwpisteperror.H>
 #include <pnor/pnorif.H>
+#include <lpc/lpcif.H>
 #ifdef CONFIG_BMC_IPMI
 #include <ipmi/ipmiwatchdog.H>      //IPMI watchdog timer
 #include <ipmi/ipmipowerstate.H>    //IPMI System ACPI Power State
@@ -1953,6 +1954,18 @@ errlHndl_t IStepDispatcher::sendProgressCode(bool i_needsLock)
     Util::writeScratchReg( SPLESS::MBOX_SCRATCH_REG5,
                            l_scratch5.data32 );
 
+#ifdef CONFIG_ISTEP_LPC_PORT80_DEBUG
+    // Starting port 80h value for hostboot isteps.  Each step started will
+    // increase the value by one.
+    static uint8_t port80_val = 0x30;
+    static size_t port80_len = sizeof(port80_val);
+    errlHndl_t port80_err = NULL;
+    port80_err = deviceWrite(TARGETING::MASTER_PROCESSOR_CHIP_TARGET_SENTINEL,
+                             &port80_val, port80_len,
+                             DEVICE_LPC_ADDRESS(LPC::TRANS_IO, 0x80));
+    delete port80_err;  // ignore any error
+    port80_val++;
+#endif
 
     //--- Display step on serial console
 #ifdef CONFIG_CONSOLE_OUTPUT_PROGRESS


### PR DESCRIPTION
Adds optional support using symbol CONFIG_PORT80_DEBUG which when enabled will send an LPC I/O write transaction to port 0x80 before starting each ipstep.

When combined with bmc kernel support in https://github.com/openbmc/linux/commit/793ab2b38d94711dab786a9523f45cd55f0ffc94 the BMC can watch and report the boot progress without depending on IPMI support.

Also fixes PBAMFIR error reporting to mask harmless LPC/OPB timeout errors which will occur if the BMC is not listening on this port.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/hostboot/104)
<!-- Reviewable:end -->
