### PR TITLE
fapi2: Correct function name in platPutScom() error message

### DIFF
--- a/src/usr/fapi2/plat_hw_access.C
+++ b/src/usr/fapi2/plat_hw_access.C
@@ -179,7 +179,7 @@ ReturnCode platPutScom(const Target<TARGET_TYPE_ALL>& i_target,
         }
         else
         {
-            FAPI_ERR("platPutScom: deviceRead returns error!");
+            FAPI_ERR("platPutScom: deviceWrite returns error!");
             FAPI_ERR("platPutScom failed - Target %s, Addr %.16llX",
                      l_targName, i_address);
                      l_rc.setPlatDataPtr(reinterpret_cast<void *> (l_err));


### PR DESCRIPTION
platPutScom() calls deviceWrite(), not deviceRead(). Fix the error message
accordingly.

Signed-off-by: Andrew Donnellan <andrew.donnellan@au1.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/hostboot/106)
<!-- Reviewable:end -->
