### PR TITLE
sbe_update: Poke the watchdog after each seeprom update action

### DIFF
--- a/src/usr/sbe/sbe_update.C
+++ b/src/usr/sbe/sbe_update.C
@@ -55,6 +55,7 @@
 #include <sbe/sbe_update.H>
 #ifdef CONFIG_BMC_IPMI
 #include <ipmi/ipmisensor.H>
+#include <ipmi/ipmiwatchdog.H>
 #endif
 #include <initservice/istepdispatcherif.H>
 #ifdef CONFIG_SECUREBOOT
@@ -421,6 +422,22 @@ namespace SBE
                                TARGETING::get_huid(sbeState.target));
                     errlCommit( err, SBE_COMP_ID );
                 }
+
+                /**********************************************/
+                /*   Reset the watchdog after each Action     */
+                /**********************************************/
+#ifdef CONFIG_BMC_IPMI
+                err = IPMIWATCHDOG::resetWatchDogTimer();
+
+                if( err )
+                {
+                    TRACFCOMP( g_trac_sbe,
+                               INFO_MRK"updateProcessorSbeSeeproms(): "
+                               "resetWatchDogTimer() Failed rc=0x%.4X",
+                               err->reasonCode());
+                    errlCommit( err, SBE_COMP_ID );
+                }
+#endif
 
                 // Push this sbeState onto the vector
                 sbeStates_vector.push_back(sbeState);


### PR DESCRIPTION
Normally the watchdog is only poked before each istep. During the SBE
update istep the process of flashing the SBE can take too long for the
default watchdog. Instead of only poking the watchdog at the end of the
istep, also poke the watchdog after each flash action.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/hostboot/108)
<!-- Reviewable:end -->
