### PR TITLE
buildsbepart: sort EC images for consistent output

### DIFF
--- a/src/build/buildpnor/buildSbePart.pl
+++ b/src/build/buildpnor/buildSbePart.pl
@@ -187,7 +187,7 @@ sub genOutputImage
     print $FILEHANDLE pack('N', 1);
 
     #Insert header data for each EC provided
-    for $key ( keys %{$i_ecImgs})
+    for $key (sort { $a <=> $b} keys %{$i_ecImgs})
     {
         trace(2, "$this_func: Inserting header for EC=$key");
         my $filesize = -s $$i_ecImgs{$key};
@@ -221,7 +221,7 @@ sub genOutputImage
     close $FILEHANDLE;
 
     #Insert actual image for each EC provided
-    for $key ( keys %{$i_ecImgs})
+    for $key (sort { $a <=> $b} keys %{$i_ecImgs})
     {
         trace(2, "$this_func: Inserting data for EC=$key, offset=$ecOffsets{$key}");
 


### PR DESCRIPTION
Perl default enumeration over hash keys doesn't seem to be
stable.  In order to make a reproducible build sort the EC
images so they end up in the same order each time.

Change-Id: I79b77762316038a0642e0a17babbef4b492c7ad0
Signed-off-by: Robert Lippert <rlippert@google.com>