### PR TITLE
ipmi: add support for reading SEL time from BMC

### DIFF
--- a/src/include/usr/ipmi/ipmiif.H
+++ b/src/include/usr/ipmi/ipmiif.H
@@ -245,6 +245,9 @@ namespace IPMI
 
 
     // Storage messages
+    inline const command_t get_sel_time(void)
+    { return std::make_pair(NETFUN_STORAGE, 0x48); }
+
     inline const command_t set_sel_time(void)
     { return std::make_pair(NETFUN_STORAGE, 0x49); }
 

--- a/src/include/usr/ipmi/ipmisel.H
+++ b/src/include/usr/ipmi/ipmisel.H
@@ -312,6 +312,12 @@ namespace IPMISEL
     void send_esel(IPMISEL::eselInitData * i_data,
           errlHndl_t &o_err, IPMI::completion_code &o_cc);
 
+    /**
+     * @brief read the SEL time
+     * @return    time from unix epoch or 0 on error
+     */
+    uint32_t get_sel_time();
+
 } // namespace IPMISEL
 
 #ifndef __HOSTBOOT_RUNTIME

--- a/src/usr/ipmi/ipmisel.C
+++ b/src/usr/ipmi/ipmisel.C
@@ -468,6 +468,26 @@ void send_esel(eselInitData * i_data,
     return;
 } // send_esel
 
+uint32_t get_sel_time()
+{
+    uint8_t *data = NULL;
+    size_t len = 0;
+    errlHndl_t l_err;
+    IPMI::completion_code l_cc = IPMI::CC_UNKBAD;
+
+    l_err = IPMI::sendrecv( IPMI::get_sel_time(), l_cc, len, data );
+    if( l_err || l_cc != IPMI::CC_OK || len != sizeof(uint32_t) )
+    {
+        delete l_err;
+        delete [] data;
+        return 0;
+    }
+
+    uint32_t timet = le32toh(*reinterpret_cast<uint32_t*>(data));
+    delete [] data;
+    return timet;
+}
+
 } // IPMISEL
 
 #ifndef __HOSTBOOT_RUNTIME


### PR DESCRIPTION
The SEL time is used as the equivalent of the RTC on OpenPOWER platforms
and can be used to timestamp events.