### PR TITLE
hwas: skip reading ID/EC data from BMC

### DIFF
--- a/src/usr/hwas/common/hwas.C
+++ b/src/usr/hwas/common/hwas.C
@@ -311,7 +311,8 @@ errlHndl_t discoverTargets()
 
             if( (pTarget->getAttr<ATTR_CLASS>() == CLASS_CHIP) &&
                 (pTarget->getAttr<ATTR_TYPE>() != TYPE_TPM) &&
-                (pTarget->getAttr<ATTR_TYPE>() != TYPE_SP) )
+                (pTarget->getAttr<ATTR_TYPE>() != TYPE_SP) &&
+                (pTarget->getAttr<ATTR_TYPE>() != TYPE_BMC) )
             {
                 // read Chip ID/EC data from these physical chips
                 errl = platReadIDEC(pTarget);


### PR DESCRIPTION
This attempt to read the ID/EC data causes a spurious recoverable
error to be generated on each boot from the devicefw associator
which does not know how to read the BMC via FSI.

Change-Id: I559de70d95ff720f4ab84d959746deca13f8dea1
Signed-off-by: Robert Lippert <rlippert@google.com>