### PR TITLE
securerom: remove hbi_ImageId

### DIFF
--- a/src/securerom/secureromasm.S
+++ b/src/securerom/secureromasm.S
@@ -152,7 +152,3 @@ _rom_sreset:
     nop
 
 .section .data
-
-.global hbi_ImageId
-hbi_ImageId:
-    .space 128


### PR DESCRIPTION
Similar to commit 951f02c32769 ("bootloader: Remove hbi_ImageId"), the
ImageId present in the securerom is now munged into the bootloader
as part of the build process resulting in unnecessary SBE updates.

Change-Id: I1115b20fc2bc0791043dc5cfae052d2eab431ca5
Signed-off-by: Robert Lippert <rlippert@google.com>