### PR TITLE
Modify eSEL script to not ignore cases for command line options

### DIFF
--- a/src/build/debug/eSEL.pl
+++ b/src/build/debug/eSEL.pl
@@ -27,7 +27,7 @@ use strict;
 use Cwd;
 use POSIX;
 use Switch;
-use Getopt::Long;
+use Getopt::Long qw(:config no_ignore_case);
 use File::Basename;
 use Data::Dumper;
 use File::Copy qw(copy);


### PR DESCRIPTION
By default Perl's Getopt::Long will ignore case for option names. This
causes conflict between for '-P' and '-p' options that provide BMC
password and decode option respectively. Below is an example of failed
run with command having both '-P' and '-p' used:

$./eSEL.pl -t <ip-addr>  -p get_and_decode_ami -U ADMIN -P ADMIN
***ERROR: Incorrect option provided.
Specify an option with -p <option>.

To fix this the Getopt::Long import is configured to not ignore the
case of option names by using the 'no_ignore_case' module config
option at import time. With the fix the command above works as
expected:

$./eSEL.pl -t <ip-addr>  -p get_and_decode_ami -U ADMIN -P ADMIN
Found 69 eSELs with PEL data

Signed-off-by: Vaibhav Jain <vaibhav@linux.vnet.ibm.com>