### PR TITLE
Report processor VRML PN/SN in VPD format that can be parsed by skiboot

### DIFF
--- a/src/include/usr/vpd/mvpdenums.H
+++ b/src/include/usr/vpd/mvpdenums.H
@@ -124,6 +124,7 @@ enum mvpdKeyword
     L7          = 0x29,
     L8          = 0x2A,
     pdW         = 0x2B,
+    RT          = 0x2C,
 
     // Last Keyword
     MVPD_LAST_KEYWORD,

--- a/src/usr/hdat/hdatpcrd.C
+++ b/src/usr/hdat/hdatpcrd.C
@@ -47,33 +47,18 @@ extern trace_desc_t *g_trac_hdat;
  */
 vpdData procVpdData[] =
 {
-    { MVPD::VINI, MVPD::DR },
-    { MVPD::VINI, MVPD::VZ },
-    { MVPD::VINI, MVPD::CC },
-    { MVPD::VINI, MVPD::CE },
-    { MVPD::VINI, MVPD::FN },
-    { MVPD::VINI, MVPD::PN },
-    { MVPD::VINI, MVPD::SN },
-    { MVPD::VINI, MVPD::PR },
-    { MVPD::VINI, MVPD::HE },
-    { MVPD::VINI, MVPD::CT },
-    { MVPD::VINI, MVPD::HW },
+    { MVPD::VRML, MVPD::RT },
+    { MVPD::VRML, MVPD::VD },
+    { MVPD::VRML, MVPD::PN },
+    { MVPD::VRML, MVPD::SN },
  };
 
 const HdatKeywordInfo l_mvpdKeywords[] =
 {
-    { MVPD::DR, "DR" },
-    { MVPD::VZ, "VZ" },
-    { MVPD::CC, "CC" },
-    { MVPD::CE, "CE" },
-    { MVPD::FN, "FN" },
+    { MVPD::RT, "RT" },
+    { MVPD::VD, "VD" },
     { MVPD::PN, "PN" },
     { MVPD::SN, "SN" },
-    { MVPD::PR, "PR" },
-    { MVPD::HE, "HE" },
-    { MVPD::CT, "CT" },
-    { MVPD::HW, "HW" },
-
 };
 
 /*******************************************************************************

--- a/src/usr/vpd/ipvpd.C
+++ b/src/usr/vpd/ipvpd.C
@@ -1786,6 +1786,20 @@ errlHndl_t IpVpdFacade::findKeywordAddr ( const char * i_keywordName,
                          record,
                          i_target,
                          i_args.location );
+
+        // If we were looking for the Record Type (RT) keyword, we are done.
+        if (memcmp( i_keywordName, "RT", KEYWORD_BYTE_SIZE ) == 0) {
+            // send back the relevant data
+            o_keywordSize = RECORD_BYTE_SIZE;
+            o_byteAddr = offset - i_offset; //make address relative
+
+            // found our match, break out
+            matchesFound++;
+            if ( matchesFound == i_index + 1 ) {
+                break;
+            }
+        }
+
         offset += RECORD_BYTE_SIZE;
 
         if( err )

--- a/src/usr/vpd/mvpd.H
+++ b/src/usr/vpd/mvpd.H
@@ -135,6 +135,7 @@ namespace MVPD
         { L7, "L7" },
         { L8, "L8" },
         { pdW, "#W" },
+        { RT,  "RT" },
 
         // -------------------------------------------------------------------
         // DO NOT USE!!  This is for test purposes ONLY!


### PR DESCRIPTION
This is the hostboot part of a potential fix for open-power/zaius-openpower#21.

Record the processor MVPD VRML (instead of VINI) record into the HDAT as the processor VPD which shows up in the "ibm,vpd" record now like this:

```
# hexdump -C /proc/device-tree/vpd/root-node-vpd@a000/enclosure@1e00/backplane@800/processor@1000/ibm,vpd
00000000  84 20 00 52 54 04 56 52  4d 4c 50 4e 07 30 31 48  |. .RT.VRMLPN.01H|
00000010  4c XX XX XX 53 4e 0c 59  41 31 XX XX XX XX XX XX  |LXXXSN.YA1XXXXXX|
00000020  XX XX XX 78                                       |XXXx|
00000024
```