### PR TITLE
ISTEP: Add PCIe dynamic bifurcation function for barreleye G2

### DIFF
--- a/src/usr/isteps/HBconfig
+++ b/src/usr/isteps/HBconfig
@@ -35,3 +35,14 @@ config PRINT_SYSTEM_INFO
     defaults n
     help
         Enables code that prints out the HWAS information for each target found during discovery
+
+config DYNAMIC_BIFURCATION
+    default n
+    help
+        Enables code that detect PEC bifurcated config.
+
+config SENSOR_BASED_BIFURCATION
+    default n
+    depends on (DYNAMIC_BIFURCATION)
+    help
+        Enable bifurcation detection API to detect the bifurcation config is enable or not through BMC sensor

--- a/src/usr/isteps/istep10/makefile
+++ b/src/usr/isteps/istep10/makefile
@@ -53,6 +53,10 @@ OBJS += call_proc_chiplet_scominit.o
 OBJS += call_proc_abus_scominit.o
 OBJS += call_proc_obus_scominit.o
 OBJS += call_proc_npu_scominit.o
+
+#Sensor Based Bifurcation implementation
+OBJS += $(if $(CONFIG_SENSOR_BASED_BIFURCATION),sensor_based_bifurcation.o)
+
 OBJS += call_proc_pcie_scominit.o
 OBJS += call_proc_scomoverride_chiplets.o
 OBJS += call_proc_chiplet_enable_ridi.o

--- a/src/usr/isteps/istep10/sensor_based_bifurcation.C
+++ b/src/usr/isteps/istep10/sensor_based_bifurcation.C
@@ -1,0 +1,109 @@
+/* IBM_PROLOG_BEGIN_TAG                                                   */
+/* This is an automatically generated prolog.                             */
+/*                                                                        */
+/* $Source: src/usr/isteps/istep10/sensor_based_bifurcation.C $           */
+/*                                                                        */
+/* OpenPOWER HostBoot Project                                             */
+/*                                                                        */
+/* Contributors Listed Below - COPYRIGHT 2016,2017                        */
+/* [+] International Business Machines Corp.                              */
+/*                                                                        */
+/*                                                                        */
+/* Licensed under the Apache License, Version 2.0 (the "License");        */
+/* you may not use this file except in compliance with the License.       */
+/* You may obtain a copy of the License at                                */
+/*                                                                        */
+/*     http://www.apache.org/licenses/LICENSE-2.0                         */
+/*                                                                        */
+/* Unless required by applicable law or agreed to in writing, software    */
+/* distributed under the License is distributed on an "AS IS" BASIS,      */
+/* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or        */
+/* implied. See the License for the specific language governing           */
+/* permissions and limitations under the License.                         */
+/*                                                                        */
+/* IBM_PROLOG_END_TAG                                                     */
+/******************************************************************************/
+// Includes
+/******************************************************************************/
+#include <stdint.h>
+#include <fapi2/target.H>
+#include <targeting/targplatutil.H>
+#include "ipmi/ipmisensor.H"
+
+#include <trace/interface.H>
+#include <initservice/taskargs.H>
+#include <errl/errlentry.H>
+#include <isteps/hwpisteperror.H>
+#include <errl/errludtarget.H>
+#include <initservice/isteps_trace.H>
+#include <initservice/initserviceif.H>
+
+
+
+namespace   ISTEP_10
+{
+
+errlHndl_t _queryIopsToBifurcateAndPhbsToDisable(
+    TARGETING::ConstTargetHandle_t const       i_pecTarget,
+    bool&                                      o_iopBifurcate,
+    TARGETING::ATTR_PROC_PCIE_PHB_ACTIVE_type& o_disabledPhbsMask)
+{
+    TRACDCOMP( ISTEPS_TRACE::g_trac_isteps_trace,
+        ENTER_MRK "_queryIopsToBifurcateAndPhbsToDisable: PEC target "
+        "HUID = 0x%08X.", i_pecTarget ?
+            i_pecTarget->getAttr<TARGETING::ATTR_HUID>() : 0);
+
+    errlHndl_t pError = NULL;
+    o_iopBifurcate = false;
+    o_disabledPhbsMask = 0;
+
+    do {
+        TARGETING::ATTR_PEC_PCIE_LANE_MASK_BIFURCATED_type laneMaskBifurcated = {0};
+        assert(i_pecTarget->tryGetAttr<
+               TARGETING::ATTR_PEC_PCIE_LANE_MASK_BIFURCATED>(
+               laneMaskBifurcated),"Failed to get "
+               "ATTR_PEC_PCIE_LANE_MASK_BIFURCATED attribute");
+        if (laneMaskBifurcated[0] || laneMaskBifurcated[1] || laneMaskBifurcated[2]
+            || laneMaskBifurcated[3]) {
+            TARGETING::Target* sys = nullptr;
+            TARGETING::targetService().getTopLevelTarget(sys);
+            assert(sys != nullptr);
+            uint32_t sensorNum = TARGETING::UTIL::getSensorNumber(sys,
+                                                      TARGETING::SENSOR_NAME_BIFURCATED);
+
+            if (sensorNum != 0xFF)
+            {
+                SENSOR::getSensorReadingData bifurcatedData;
+                SENSOR::SensorBase bifurcatedSensor(TARGETING::SENSOR_NAME_BIFURCATED, sys);
+                pError = bifurcatedSensor.readSensorData(bifurcatedData);
+                if (NULL == pError) {
+                    if ((bifurcatedData.event_status & 0x02) == 0x02) {
+                        o_iopBifurcate = true;
+                    }
+                }
+                else
+                {
+                    errlCommit(pError, ISTEP_COMP_ID);
+                }
+            }
+        }
+    // Extension point to return bifurcated IOPs and PHBs to disable.
+    // Assuming no extensions are added, the function returns no IOPs to
+    // bifurcate and no PHBs to disable
+
+    // If implemented, this function should only return error on software code
+    // bug.  Any other condition should result in IOPs not being bifurcated and
+    // host taking care of that condition.
+
+    } while(0);
+
+    TRACDCOMP( ISTEPS_TRACE::g_trac_isteps_trace,
+        EXIT_MRK "_queryIopsToBifurcateAndPhbsToDisable: EID = 0x%08X, "
+        "PLID = 0x%08X, RC = 0x%08X.",
+        ERRL_GETEID_SAFE(pError),ERRL_GETPLID_SAFE(pError),
+        ERRL_GETRC_SAFE(pError));
+
+    return pError;
+}
+
+};

--- a/src/usr/targeting/common/Targets.pm
+++ b/src/usr/targeting/common/Targets.pm
@@ -902,12 +902,10 @@ sub iterateOverChiplets
                              }
                              else
                              {
-                                 # This is our "bug" scenerio. We have found a
-                                 # connection, but that PHB element is already
-                                 # filled in the array. We need to kill the
-                                 # program.
-                                 printf("Found a duplicate connection for PEC %s PHB %s.\n",$pec_num,$phb_num);
-                                 die "Duplicate PHB bus connection found\n";
+                                 # The dynamic bifurcation feature will make duplicate connection
+                                 # for single PEC. So just post warning message for the possible
+                                 # error in other scenario.
+                                 printf("Warning: Found a duplicate connection for PEC %s PHB %s.\n",$pec_num,$phb_num);
                              }
                         }
                     }

--- a/src/usr/targeting/common/processMrw.pl
+++ b/src/usr/targeting/common/processMrw.pl
@@ -1521,13 +1521,23 @@ sub processPec
                         $pec_iop_swap |= 1 << $bitshift;
                     }
 
+                    my $pcie_bifurcated = "0";
+                    if ($targetObj->isBusAttributeDefined($phb_config_child, 0, "PCIE_BIFURCATED")) {
+                        $pcie_bifurcated = $targetObj->getBusAttribute
+                                ($phb_config_child, 0, "PCIE_BIFURCATED");
+                    }
                     # Set the lane swap for the PEC. If we find more swaps as
                     # we process the other PCI busses then we will overwrite
                     # the overall swap value with the newly computed one.
-                    $targetObj->setAttribute($target,
-                        "PEC_PCIE_IOP_SWAP_NON_BIFURCATED", $pec_iop_swap);
-                    $targetObj->setAttribute($target,
-                        "PROC_PCIE_IOP_SWAP", $pec_iop_swap);
+                    if ($pcie_bifurcated eq "1") {
+                        $targetObj->setAttribute($target,
+                            "PEC_PCIE_IOP_SWAP_BIFURCATED", $pec_iop_swap);
+                    } else {
+                        $targetObj->setAttribute($target,
+                            "PEC_PCIE_IOP_SWAP_NON_BIFURCATED", $pec_iop_swap);
+                        $targetObj->setAttribute($target,
+                            "PROC_PCIE_IOP_SWAP", $pec_iop_swap);
+                    }
 
                     $lane_mask[$lane_group][0] =
                         $targetObj->getAttribute
@@ -1537,10 +1547,15 @@ sub processPec
                         $lane_mask[0][0], $lane_mask[1][0],
                         $lane_mask[2][0], $lane_mask[3][0]);
 
-                    $targetObj->setAttribute($target, "PROC_PCIE_LANE_MASK",
-                        $lane_mask_attr);
-                    $targetObj->setAttribute($target,
-                        "PEC_PCIE_LANE_MASK_NON_BIFURCATED", $lane_mask_attr);
+                    if ($pcie_bifurcated eq "1") {
+                        $targetObj->setAttribute($target,
+                            "PEC_PCIE_LANE_MASK_BIFURCATED", $lane_mask_attr);
+                    } else {
+                        $targetObj->setAttribute($target, "PROC_PCIE_LANE_MASK",
+                            $lane_mask_attr);
+                        $targetObj->setAttribute($target,
+                            "PEC_PCIE_LANE_MASK_NON_BIFURCATED", $lane_mask_attr);
+                    }
 
                     # Only compute the HDAT attributes if they are available
                     # and have default values

--- a/src/usr/targeting/common/xmltohb/attribute_types_hb.xml
+++ b/src/usr/targeting/common/xmltohb/attribute_types_hb.xml
@@ -609,6 +609,10 @@
         <name>TPM_REQUIRED</name>
         <value>0xCC03</value>
     </enumerator>
+    <enumerator>
+        <name>BIFURCATED</name>
+        <value>0xCD03</value>
+    </enumerator>
 </enumerationType>
 
 <attribute>

--- a/src/usr/targeting/common/xmltohb/hb_customized_attrs.xml
+++ b/src/usr/targeting/common/xmltohb/hb_customized_attrs.xml
@@ -649,6 +649,10 @@
         <id>ATTR_FABRIC_PRESENT_GROUPS</id>
         <writeable/>
     </attribute>
+    <attribute>
+        <id>ATTR_PROC_PCIE_IOP_SWAP</id>
+        <writeable/>
+    </attribute>
     <!-- =====================================================================
      End of customizations definitions
      ================================================================= -->


### PR DESCRIPTION
1. Add compile time flag "CONFIG_BARRELEYE_G2_DYNAMIC_BIFURCATION" for Barreleye G2 specific code. This part of code is used to detect whether apply the bifurcation or not. So the other platform can define their own bifurcation detection code.
2. Restructure the code to apply the bifurcation value from attributes.
3. Changed the processMRW to handle the lane mask and swap for bifurcation connection for each PEC.
4. Add bifurcated sensor definition