### PR TITLE
Secure Boot: Run signtool with keepcache=true

### DIFF
--- a/src/build/buildpnor/genPnorImages.pl
+++ b/src/build/buildpnor/genPnorImages.pl
@@ -261,7 +261,7 @@ if ($secureboot)
 
 ### Open POWER signing
 my $OPEN_SIGN_REQUEST=
-    "$SIGNING_DIR/crtSignedContainer.sh --scratchDir $bin_dir ";
+    "SB_KEEP_CACHE=true $SIGNING_DIR/crtSignedContainer.sh --scratchDir $bin_dir ";
 # By default key transition container is unused
 my $OPEN_SIGN_KEY_TRANS_REQUEST = $OPEN_SIGN_REQUEST;
 


### PR DESCRIPTION
I have changed sb-signing-utls to remove the cache by default but it's
important to preserve the current behavior under op-build, as features
that rely on cache re-use depend on it.

Signed-off-by: Dave Heller <hellerda@linux.vnet.ibm.com>