### PR TITLE
IPMI Watchdog Cleanups

### DIFF
--- a/src/usr/initservice/istepdispatcher/istepdispatcher.C
+++ b/src/usr/initservice/istepdispatcher/istepdispatcher.C
@@ -389,6 +389,17 @@ void IStepDispatcher::init(errlHndl_t &io_rtaskRetErrl)
                 errlCommit(err_ipmi, INITSVC_COMP_ID );
 
             }
+
+            // Start the watchdog
+            err_ipmi = IPMIWATCHDOG::resetWatchDogTimer();
+            if(err_ipmi)
+            {
+               TRACFCOMP(g_trac_initsvc,
+                              "init: ERROR: Starting IPMI watchdog Failed");
+                err_ipmi->collectTrace("INITSVC", 1024);
+                errlCommit(err_ipmi, INITSVC_COMP_ID );
+
+            }
 #endif
 
             // Non-IStep mode (run all isteps automatically)
@@ -2942,6 +2953,17 @@ void IStepDispatcher::istepPauseSet(uint8_t i_step, uint8_t i_substep)
             {
                TRACFCOMP(g_trac_initsvc,
                               "init: ERROR: Set IPMI watchdog Failed");
+                err_ipmi->collectTrace("INITSVC", 1024);
+                errlCommit(err_ipmi, INITSVC_COMP_ID );
+
+            }
+
+            // Start the watchdog timer
+            err_ipmi = IPMIWATCHDOG::resetWatchDogTimer();
+            if(err_ipmi)
+            {
+               TRACFCOMP(g_trac_initsvc,
+                              "init: ERROR: Start IPMI watchdog Failed");
                 err_ipmi->collectTrace("INITSVC", 1024);
                 errlCommit(err_ipmi, INITSVC_COMP_ID );
 

--- a/src/usr/initservice/istepdispatcher/istepdispatcher.C
+++ b/src/usr/initservice/istepdispatcher/istepdispatcher.C
@@ -2888,9 +2888,7 @@ void IStepDispatcher::istepPauseSet(uint8_t i_step, uint8_t i_substep)
 #ifdef CONFIG_BMC_IPMI
             errlHndl_t err_ipmi = IPMIWATCHDOG::setWatchDogTimer(
                                IPMIWATCHDOG::DEFAULT_WATCHDOG_COUNTDOWN,
-                               static_cast<uint8_t>
-                                          (IPMIWATCHDOG::DO_NOT_STOP |
-                                           IPMIWATCHDOG::BIOS_FRB2), // default
+                               IPMIWATCHDOG::BIOS_FRB2,
                                IPMIWATCHDOG::NO_ACTIONS); // do nothing when
                                                           // timeout occurs
             if(err_ipmi)

--- a/src/usr/isteps/istep21/call_host_start_payload.C
+++ b/src/usr/isteps/istep21/call_host_start_payload.C
@@ -227,35 +227,10 @@ void* call_host_start_payload (void *io_pArgs)
         task_affinity_unpin();
 
 #ifdef CONFIG_BMC_IPMI
-
-        // TODO ISSUE 118082
-        // ENABLE CODE BELOW ONCE OPAL COMPLETES ipmi WATCHDOG
-#if 0
-                //run the ipmi watchdog for a longer period to transition
-                // to opel
-                errlHndl_t err_ipmi = IPMIWATCHDOG::setWatchDogTimer(
-                        IPMIWATCHDOG::DEFAULT_HB_OPAL_TRANSITION_COUNTDOWN);
-
-                if(err_ipmi)
-                {
-                TRACFCOMP(ISTEPS_TRACE::g_trac_isteps_trace,
-                                "init: ERROR: Set IPMI watchdog Failed");
-                    err_ipmi->collectTrace("ISTEPS_TRACE",256);
-                    errlCommit(err_ipmi, ISTEP_COMP_ID );
-
-                }
-#endif
-
-        // TODO ISSUE 118082
-        // REMOVE CODE BELOW ONCE OPAL COMPLETES IPMI WATCHDOG
-        // THE CODE BELOW STOPS THE IPMI TIMER FROM RUNNING
-        // TO PREVENT IT GETTING TRIGGERED DURING HB_OPAL TRANSITION
-
-        // Call setWatchdogTimer without the default DON'T STOP
-        // flag to stop the watchdog timer
+        // Run the watchdog with a longer expiration during the transition
+        // into OPAL.
         errlHndl_t err_ipmi = IPMIWATCHDOG::setWatchDogTimer(
-                IPMIWATCHDOG::DEFAULT_HB_OPAL_TRANSITION_COUNTDOWN,
-                IPMIWATCHDOG::BIOS_FRB2);
+                IPMIWATCHDOG::DEFAULT_HB_OPAL_TRANSITION_COUNTDOWN);
 
         if(err_ipmi)
         {
@@ -264,7 +239,6 @@ void* call_host_start_payload (void *io_pArgs)
                 err_ipmi->collectTrace("ISTEPS_TRACE",256);
                 errlCommit(err_ipmi, ISTEP_COMP_ID );
         }
-
 #endif
 
         // broadcast shutdown to other HB instances.


### PR DESCRIPTION
Improve our watchdog coverage during the hostboot process and during the transition into OPAL firmware.