### PR TITLE
linker: fix compiler warnings

### DIFF
--- a/src/build/linker/linker.C
+++ b/src/build/linker/linker.C
@@ -189,8 +189,8 @@ struct Object
         /**
          * CTOR default
          */
-        Object() : image(NULL), offset(0), base_addr(0), iv_output(NULL),
-                   text(), rodata(), data() {}
+        Object() : image(NULL), text(), rodata(), data(),
+                   offset(0), base_addr(0), iv_output(NULL) {}
 
         /**
          * CTOR
@@ -198,8 +198,8 @@ struct Object
          * @param[in] i_out : output FILE handle
          */
         Object(unsigned long i_baseAddr, FILE* i_out)
-            : image(NULL), offset(0), base_addr(i_baseAddr), iv_output(i_out),
-              text(), rodata(), data() {}
+            : image(NULL), text(), rodata(), data(),
+              offset(0), base_addr(i_baseAddr), iv_output(i_out) {}
 };
 
 inline bool Object::isELF()
@@ -458,7 +458,7 @@ int main(int argc, char** argv)
             bfd_putb64(count, temp64);
             fwrite(temp64, sizeof(uint64_t), 1, objects[0].iv_output);
 
-            for (int i = 0; i < all_relocations.size(); i++)
+            for (size_t i = 0; i < all_relocations.size(); i++)
             {
                 bfd_putb64(all_relocations[i], temp64);
                 fwrite(temp64, sizeof(uint64_t), 1, objects[0].iv_output);
@@ -613,6 +613,7 @@ bool Object::write_object()
     modinfo << &name[(name.find_last_of("/")+1)] << ",0x"
         << std::hex << offset + base_addr << endl;
 
+    return true;
 }
 
 //-----------------------------------------------------------------------------
@@ -824,6 +825,8 @@ bool Object::perform_local_relocations()
         cout << "\tRelocated " << i->addend << " at " << i->address << " to "
             << relocation << endl;
     }
+
+    return true;
 }
 
 //-----------------------------------------------------------------------------
@@ -934,6 +937,8 @@ bool Object::perform_global_relocations()
             throw range_error(oss.str());
         }
     }
+
+    return true;
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
In Fedora 28 (x86_64) the linker binary, produced by GCC 8.1.1, always ended in an infinite loop in which it repeatedly appended some text to `*.lnkout.bz2` file and `*.bin.modinfo` file.

Example:
```
.hbicore.lnkout.bz2:  Error writing to output.
                      Success

hbicore.bin.modinfo:  hbicore.elf,0x0
```

The GCC was also displaying warnings about missing return statements (`-Wreturn-type`). When these warnings were fixed, the problem with infinite loop disappeared. This problem also never appeared when the `-O0` flag was used.

While being there, also fix some warnings that happen with the `-Wall` flag.

Signed-off-by: Jan Hlavac <jhlavac@redhat.com>