### PR TITLE
Secure Boot: Don't override user setting of SB_KEEP_CACHE

### DIFF
--- a/src/build/buildpnor/genPnorImages.pl
+++ b/src/build/buildpnor/genPnorImages.pl
@@ -269,8 +269,14 @@ if ($secureboot)
 }
 
 ### Open POWER signing
+# In most cases this is desired, but do not override a value set by user
+if(!$ENV{'SB_KEEP_CACHE'})
+{
+    $ENV{'SB_KEEP_CACHE'} = "true";
+}
+
 my $OPEN_SIGN_REQUEST=
-    "SB_KEEP_CACHE=true $SIGNING_DIR/crtSignedContainer.sh --scratchDir $bin_dir ";
+    "$SIGNING_DIR/crtSignedContainer.sh --scratchDir $bin_dir ";
 # By default key transition container is unused
 my $OPEN_SIGN_KEY_TRANS_REQUEST = $OPEN_SIGN_REQUEST;
 


### PR DESCRIPTION
The previous patch set SB_KEEP_CACHE=true in genPnorImages.pl in a way that
would override the user setting.  This was a bad idea.  The desired behavior
is to set SB_KEEP_CACHE=true but only if it has not already been set (through
environment) by the user.

Signed-off-by: Dave Heller <hellerda@us.ibm.com>