### PR TITLE
hostboot: Add a printed out banner add startup

### DIFF
--- a/src/usr/console/daemon.C
+++ b/src/usr/console/daemon.C
@@ -5,9 +5,9 @@
 /*                                                                        */
 /* OpenPOWER HostBoot Project                                             */
 /*                                                                        */
-/* Contributors Listed Below - COPYRIGHT 2014                             */
-/* [+] International Business Machines Corp.                              */
+/* Contributors Listed Below - COPYRIGHT 2014,2017                        */
 /* [+] Google Inc.                                                        */
+/* [+] International Business Machines Corp.                              */
 /*                                                                        */
 /*                                                                        */
 /* Licensed under the Apache License, Version 2.0 (the "License");        */
@@ -31,6 +31,8 @@
 #include <initservice/initserviceif.H>
 #include "uart.H"
 #include "daemon.H"
+
+extern char hbi_ImageId[];
 
 namespace CONSOLE
 {
@@ -69,6 +71,13 @@ namespace CONSOLE
             Uart::g_device = new Uart();
             Uart::g_device->initialize();
         }
+
+        // Display a banner denoting the hostboot version
+        char banner[256];
+        snprintf(banner, sizeof(banner),
+                 "\n\n--== Welcome to Hostboot %s ==--\n\n",
+                 hbi_ImageId);
+        _display(banner);
 
         while(1)
         {


### PR DESCRIPTION
This better clarifies the ImageId immediately to the end user.

Resolves #90

Signed-off-by: William A. Kennington III <wak@google.com>
Change-Id: Ieab56b9d1902aebbbf9f4f093f0a4a13c41d81f7
Reviewed-on: http://ralgit01.raleigh.ibm.com/gerrit1/37457
Reviewed-by: William G. Hoffa <wghoffa@us.ibm.com>
Tested-by: Jenkins Server <pfd-jenkins+hostboot@us.ibm.com>
Tested-by: Jenkins OP Build CI <op-jenkins+hostboot@us.ibm.com>
Tested-by: FSP CI Jenkins <fsp-CI-jenkins+hostboot@us.ibm.com>
Reviewed-by: Dean Sanner <dsanner@us.ibm.com>
Reviewed-by: Daniel M. Crowell <dcrowell@us.ibm.com>