### PR TITLE
Fix incorrect syntax in addimgid shell script

### DIFF
--- a/src/build/tools/addimgid
+++ b/src/build/tools/addimgid
@@ -52,5 +52,5 @@ if (($imageId =~ m/Unknown-Image/) ||  	# Couldn't find git describe tag.
     $imageId = $imageId."/".$ENV{"USER"};
 }
 
-system("echo -n $imageId | dd of=$img conv=notrunc bs=1 seek=$address count=127 >& /dev/null");
+system("echo -n $imageId | dd of=$img conv=notrunc bs=1 seek=$address count=127");
 exit $?


### PR DESCRIPTION
Construction '>&' is a bash specific redirection.
Perl's `system` call uses posix shell (sh), not bash.
As a result, during the call to addimgid we got error:
'Syntax error: Bad fd number', dd utility is not executed.
Anyway, it is a bad idea to hide build logs.

Signed-off-by: Artem Senichev <a.senichev@yadro.com>