### PR TITLE
Fixed eeprom detection in the device tree

### DIFF
--- a/src/usr/devtree/bld_devtree.C
+++ b/src/usr/devtree/bld_devtree.C
@@ -443,6 +443,7 @@ void add_i2c_info( const TARGETING::Target* i_targ,
     } atmel_ids[] = {
         { "atmel,24c128", 16*KILOBYTE, 2 },
         { "atmel,24c256", 32*KILOBYTE, 2 },
+        { "atmel,24c512", 64*KILOBYTE, 2 },
         { "atmel,24c02",  256,         1 },
 
         //Currently our minimum is 1KB, even for the 256 byte SPD
@@ -629,7 +630,7 @@ void add_i2c_info( const TARGETING::Target* i_targ,
                      a++ )
                 {
                     if( (atmel_ids[a].byteSize == (KILOBYTE*eep2->sizeKB))
-                        || (atmel_ids[a].addrBytes == eep2->addrBytes) )
+                        && (atmel_ids[a].addrBytes == eep2->addrBytes) )
                     {
                         l_compat = atmel_ids[a].name;
                         l_foundit = true;


### PR DESCRIPTION
This commit fixed bug with determining the atmel compatible eeprom
in the device tree.
In addition, I added support for eeprom atmel-24c512 to the device
tree. Now the Hostboot sets the correct size (64Kb) of the mvpd,
cvpd, pvpd in the device tree for the i2c OS driver.

Signed-off-by: Maxim Polyakov <m.polyakov@yadro.com>