### PR TITLE
Update hostboot to allow DDR4-SORDIMM modules to be used.

### DIFF
--- a/src/import/chips/p9/procedures/hwp/memory/lib/eff_config/nimbus_pre_data_engine.C
+++ b/src/import/chips/p9/procedures/hwp/memory/lib/eff_config/nimbus_pre_data_engine.C
@@ -367,6 +367,11 @@ const std::vector< std::pair<uint8_t, uint8_t> > pre_data_engine<mss::proc_type:
     {1, fapi2::ENUM_ATTR_EFF_DIMM_TYPE_RDIMM},
     {2, fapi2::ENUM_ATTR_EFF_DIMM_TYPE_UDIMM},
     {4, fapi2::ENUM_ATTR_EFF_DIMM_TYPE_LRDIMM},
+    {5, fapi2::ENUM_ATTR_EFF_DIMM_TYPE_RDIMM}, /* Mini RDIMM */
+    {6, fapi2::ENUM_ATTR_EFF_DIMM_TYPE_UDIMM}, /* Mini UDIMM */
+    /* 0x7: Reserved */
+    {8, fapi2::ENUM_ATTR_EFF_DIMM_TYPE_RDIMM}, /* SO RDIMM */
+    {9, fapi2::ENUM_ATTR_EFF_DIMM_TYPE_UDIMM}, /* SO UDIMM */
     // All others reserved or not supported
 };
 

--- a/src/import/chips/p9/procedures/hwp/memory/lib/spd/spd_factory.C
+++ b/src/import/chips/p9/procedures/hwp/memory/lib/spd/spd_factory.C
@@ -97,6 +97,8 @@ fapi2::ReturnCode raw_card_factory(const fapi2::Target<TARGET_TYPE_DIMM>& i_targ
     switch(l_dimm_type)
     {
         case RDIMM:
+        case SORDIMM:
+        case MINIRDIMM:
 
             // TODO:RTC178807 - Update how NVDIMMs are handled once more are up and running in the lab
             // NVDIMM is currently considered differently than all other rdimm raw cards, due to settings differences

--- a/src/import/generic/memory/lib/spd/spd_checker.H
+++ b/src/import/generic/memory/lib/spd/spd_checker.H
@@ -185,6 +185,8 @@ static inline bool is_dimm_type_valid(const uint8_t i_dimm_type)
     {
         case RDIMM:
         case LRDIMM:
+        case SORDIMM:
+        case MINIRDIMM:
             l_result = true;
             break;
 

--- a/src/import/generic/memory/lib/spd/spd_factory_pattern.C
+++ b/src/import/generic/memory/lib/spd/spd_factory_pattern.C
@@ -295,6 +295,8 @@ fapi2::ReturnCode factories::dimm_module_select_param(parameters& o_param) const
     switch(iv_dimm_type)
     {
         case RDIMM:
+        case SORDIMM:
+        case MINIRDIMM:
             o_param = RDIMM_MODULE;
             break;
 

--- a/src/import/generic/memory/lib/utils/shared/mss_generic_consts.H
+++ b/src/import/generic/memory/lib/utils/shared/mss_generic_consts.H
@@ -231,7 +231,7 @@ enum dimm_type
     RDIMM = 0b0001,
     LRDIMM = 0b0100,
     SORDIMM = 0b1000,
-    MINIRDIMM = 0b1001,
+    MINIRDIMM = 0b0101,
 };
 
 enum guard_band : uint16_t

--- a/src/import/generic/memory/lib/utils/shared/mss_generic_consts.H
+++ b/src/import/generic/memory/lib/utils/shared/mss_generic_consts.H
@@ -230,6 +230,8 @@ enum dimm_type
 {
     RDIMM = 0b0001,
     LRDIMM = 0b0100,
+    SORDIMM = 0b1000,
+    MINIRDIMM = 0b1001,
 };
 
 enum guard_band : uint16_t

--- a/src/usr/vpd/spd.C
+++ b/src/usr/vpd/spd.C
@@ -2014,12 +2014,16 @@ errlHndl_t getModType ( modSpecTypes_t & o_modType,
         }
         else if (SPD_DDR4_TYPE == i_memType)
         {
-            if ((MOD_TYPE_DDR4_UDIMM == modTypeVal) ||
-                (MOD_TYPE_DDR4_SO_DIMM == modTypeVal))
+            if ((MOD_TYPE_DDR4_UDIMM == modTypeVal)      ||
+                (MOD_TYPE_DDR4_SO_DIMM == modTypeVal)    ||
+                (MOD_TYPE_DDR4_MINI_UDIMM == modTypeVal) ||
+                (MOD_TYPE_DDR4_SO_UDIMM == modTypeVal))
             {
                 o_modType = UMM;
             }
-            else if (MOD_TYPE_DDR4_RDIMM == modTypeVal)
+            else if ((MOD_TYPE_DDR4_RDIMM == modTypeVal)      ||
+                     (MOD_TYPE_DDR4_MINI_RDIMM == modTypeVal) ||
+                     (MOD_TYPE_DDR4_SO_RDIMM == modTypeVal))
             {
                 o_modType = RMM;
             }

--- a/src/usr/vpd/spd.H
+++ b/src/usr/vpd/spd.H
@@ -73,10 +73,15 @@ enum
     MOD_TYPE_DDR3_SO_RDIMM   = 0x09,
     MOD_TYPE_DDR3_SO_CDIMM   = 0x0a,
     MOD_TYPE_DDR3_LRDIMM     = 0x0b,
+
     MOD_TYPE_DDR4_RDIMM      = 0x01,
     MOD_TYPE_DDR4_UDIMM      = 0x02,
     MOD_TYPE_DDR4_SO_DIMM    = 0x03,
     MOD_TYPE_DDR4_LRDIMM     = 0x04,
+    MOD_TYPE_DDR4_MINI_RDIMM = 0x05,
+    MOD_TYPE_DDR4_MINI_UDIMM = 0x06,
+    MOD_TYPE_DDR4_SO_RDIMM   = 0x08,
+    MOD_TYPE_DDR4_SO_UDIMM   = 0x09,
 
     DIMM_SPD_SECTION_SIZE = 0x200,  // Size each DIMM SPD section
     DIMM_SPD_MAX_SECTIONS = 512,    // Maximum number of sections


### PR DESCRIPTION
Add support for the module type in the SPD parser.
This change has been tested with the VR9FR2G7228JBKSBD4 module
    from Viking Technologies: 2666MHz DDR4-SORDIMM, rank 2, 16GB

Note: Above mentioned module need an additional patch due to an
    unexpected SPD manufacturer being detected.

Signed-off-by: Evan Lojewski <github@meklort.com>