### PR TITLE
Add additional 2133 and 1866 ps values for spd parsing.

### DIFF
--- a/src/import/generic/memory/lib/utils/conversions.H
+++ b/src/import/generic/memory/lib/utils/conversions.H
@@ -88,7 +88,9 @@ static const std::vector<std::pair<uint64_t, uint64_t>> FREQ_TO_CLOCK_PERIOD =
 {
     {DIMM_SPEED_1600, 1250}, // DDR4
     {DIMM_SPEED_1866, 1071}, // DDR4
+    {DIMM_SPEED_1866, 1072}, // DDR4 - rounding error.
     {DIMM_SPEED_2133,  937}, // DDR4
+    {DIMM_SPEED_2133,  938}, // DDR4 - rounding error.
     {DIMM_SPEED_2400,  833}, // DDR4
     {DIMM_SPEED_2666,  750}, // DDR4
     {DIMM_SPEED_2933,  682}, // DDR4


### PR DESCRIPTION
On some RAM modules, unexpected ps values are reported that are
 off by 1 from the expected JEDEC value.
This patch adds additional values to the lookup table, appearing second
 to ensure that the inverse lookup always find the correct value first.

This change was tested with the M393A1G40DB0-CPB RAM module which
was rejected by the previous code due to the time_in_ps being 938
instead of the previously expected value of 937.

Memtester was run with the resulting configuration and shows no errors:
/ # /usr/sbin/memtester  6G 4
memtester version 4.3.0 (64-bit)
Copyright (C) 2001-2012 Charles Cazabon.
Licensed under the GNU General Public License version 2 (only).

pagesize is 65536
pagesizemask is 0xffffffffffff0000
want 6144MB (6442450944 bytes)
got  6144MB (6442450944 bytes), trying mlock ...locked.
Loop 1/4:
  Stuck Address       : ok
  Random Value        : ok
  Compare XOR         : ok
  Compare SUB         : ok
  Compare MUL         : ok
  Compare DIV         : ok
  Compare OR          : ok
  Compare AND         : ok
  Sequential Increment: ok
  Solid Bits          : ok
  Block Sequential    : ok
  Checkerboard        : ok
  Bit Spread          : ok
  Bit Flip            : ok
  Walking Ones        : ok
  Walking Zeroes      : ok
  8-bit Writes        : ok
  16-bit Writes       : ok

Signed-off-by: Evan Lojewski <github@meklort.com>