### PR TITLE
HTMGT: Handle 'unsupported' status of DCMI messages

### DIFF
--- a/src/usr/ipmiext/ipmidcmi.C
+++ b/src/usr/ipmiext/ipmidcmi.C
@@ -37,8 +37,9 @@ namespace SENSOR
 {
     enum dcmi_cc
     {
-        POWER_LIMIT_ACTIVE     = 0x00,
-        POWER_LIMIT_NOT_ACTIVE = 0x80,
+        POWER_LIMIT_ACTIVE        = 0x00,
+        POWER_LIMIT_NOT_ACTIVE    = 0x80,
+        POWER_LIMIT_NOT_SUPPORTED = 0xC1
     };
 
     // fetch the user defined power limit stored on the BMC
@@ -70,9 +71,12 @@ namespace SENSOR
 
         if( l_err == NULL )
         {
-            // make sure the completion code is good, then read the bytes
-            if( (l_cc == POWER_LIMIT_NOT_ACTIVE) ||
-                    (l_cc == POWER_LIMIT_ACTIVE) )
+            if( l_cc == POWER_LIMIT_NOT_SUPPORTED )
+            {
+                TRACFCOMP(g_trac_ipmi, "Power limit is not supported by BMC");
+            }
+            else if( (l_cc == POWER_LIMIT_NOT_ACTIVE) ||
+                     (l_cc == POWER_LIMIT_ACTIVE) )
             {
                 // from the dcmi spec
                 // byte 1   completion code


### PR DESCRIPTION
OpenBMC responses with status UNSUPPORTED (0xC1) for power limit IPMI requests:
https://github.com/openbmc/phosphor-host-ipmid/commit/2c2af2ca713f56b117ad2c8c1a1f0e370b7c2d9c
Hostboot doesn't handle that status properly, and, as a result, register an
error and stop OCC initialization procedure.

According to section 6.6 Power management of DCMI specification, if power
management feature is disabled, the related commands should be unsupported.

Signed-off-by: Artem Senichev <a.senichev@yadro.com>