### PR TITLE
ADD imageId for P8 hostboot version.

### DIFF
--- a/src/build/tools/addimgid
+++ b/src/build/tools/addimgid
@@ -39,6 +39,10 @@ my $address = hex `${PREFIX}nm $src -C | grep $imageIdSym | colrm 17`;
 my $imageId = $ENV{'HOSTBOOT_VERSION'};
 if ($imageId eq '')
 {
+    $imageId = $ENV{'HOSTBOOT_P8_VERSION'};
+}
+if ($imageId eq '')
+{
     $imageId = `git describe --dirty || echo Unknown-Image \`git rev-parse --short HEAD\``;
 }
 


### PR DESCRIPTION
This patch sets imageId = HOSTBOOT_P8_VERSION because there is no HOSTBOOT_VERSION when doing P8DTU build.

Signed-off-by: Carey Zhang <careyz@supermicro.com>