### PR TITLE
devtree: Add ranges to "ibm,hostboot" node

### DIFF
--- a/src/usr/devtree/bld_devtree.C
+++ b/src/usr/devtree/bld_devtree.C
@@ -1393,6 +1393,7 @@ void add_reserved_mem(devTree * i_dt,
     dtOffset_t rootMemNode = i_dt->addNode(rootNode, "ibm,hostboot");
     i_dt->addPropertyCell32(rootMemNode, "#address-cells", 2);
     i_dt->addPropertyCell32(rootMemNode, "#size-cells", 2);
+    i_dt->addProperty(rootMemNode, "ranges");
     dtOffset_t reservedMemNode = i_dt->addNode(rootMemNode, "reserved-memory");
     i_dt->addPropertyCell32(reservedMemNode, "#address-cells", 2);
     i_dt->addPropertyCell32(reservedMemNode, "#size-cells", 2);


### PR DESCRIPTION
This node contain #address-cell/#size-cells without "ranges"
property. For this reason, "dtc" utility displays the following
warnings:

 /ibm,hostboot: unnecessary #address-cells/#size-cells without
 "ranges" or child "reg" property

Commit fixes this bug by adding the "ranges" property.

Signed-off-by: Maxim Polyakov <m.polyakov@yadro.com>