### PR TITLE
devtree: remove #address/size cell from "bmc" node

### DIFF
--- a/src/usr/devtree/bld_devtree.C
+++ b/src/usr/devtree/bld_devtree.C
@@ -2688,10 +2688,6 @@ errlHndl_t bld_fdt_bmc(devTree * i_dt, bool i_smallTree)
         bmcNode = i_dt->addNode(rootNode, bmcNodeName);
     }
 
-    /* Add the # address & size cell properties to /bmc node. */
-    i_dt->addPropertyCell32(bmcNode, "#address-cells", 1);
-    i_dt->addPropertyCell32(bmcNode, "#size-cells", 0);
-
     i_dt->addPropertyString(bmcNode, "name", bmcNodeName );
 
     /* create a node to hold the sensors */


### PR DESCRIPTION
The child node ("sensors") from “bmc” in the device tree doesn`t
contain "reg" property with address information. For this reason,
the properties #address-cell and #size-cell isn`t needed in "bmc"
node. Commit removes these properties.

In addition, it allows the dtc utility to get rid of the warning:

(avoid_unnecessary_addr_size): /bmc: unnecessary #address-cells
/#size-cells without "ranges" or child "reg" property

Signed-off-by: Maxim Polyakov <m.polyakov@yadro.com>