### PR TITLE
Fix incorrect index offsets in generateTargetingImage

### DIFF
--- a/src/usr/targeting/common/xmltohb/xmltohb.pl
+++ b/src/usr/targeting/common/xmltohb/xmltohb.pl
@@ -6683,7 +6683,7 @@ sub generateTargetingImage {
                     # list, num associations x 8 byte pointers to association lists
 
                     # length(double + quad + quad + # associations x quad)
-                    $index *= (20 + 8 * (scalar @associationTypes));
+                    $index *= (20 + 6 * (scalar @associationTypes));
                     $attrhash{$attributeId}->{default} = $index + $firstTgtPtr;
                 }
 


### PR DESCRIPTION
Commit 63a9aa5 reworked the index generation code, inadvertently
replacing a fixed offset of 6 * quad with a dynamic 8 * quad.

Use the correct 6 * code multiplier with the new dynamic
associationTypes count code.

Verified to fix #173 on a Blackbird test box.

Signed-off-by: Timothy Pearson <tpearson@raptorengineering.com>