### PR TITLE
Allow to set image id string via environment

### DIFF
--- a/src/build/tools/addimgid
+++ b/src/build/tools/addimgid
@@ -37,7 +37,7 @@ $imgBase =~ s/.*\///;
 
 my $PREFIX = $ENV{'CROSS_PREFIX'};
 my $address = hex `${PREFIX}nm $src -C | grep $imageIdSym | colrm 17`;
-my $imageId = $ENV{'HOSTBOOT_VERSION'};
+my $imageId = $ENV{'HOSTBOOT_IMAGEID'};
 if ($imageId eq '')
 {
     $imageId = $ENV{'HOSTBOOT_P8_VERSION'};


### PR DESCRIPTION
Hostboot's Image Id is the first text string that a customer sees
when the host starts booting.
By default, image id is a version of hostboot itself. This
patch allows to change it into the more meaningful value, such as
a machine name, release version number of the firmware and so on.

Custom image id string can be specified in the environment variable
HOSTBOOT_IMAGEID. If this variable is not defined, a build script
uses HOSTBOOT_P8_VERSION value. HOSTBOOT_VERSION removed because
it is not defined for P8 builds.

Signed-off-by: Artem Senichev <a.senichev@yadro.com>