### PR TITLE
ipmi fru: Add membufs manufacturing date

### DIFF
--- a/src/usr/ipmiext/ipmifruinv.C
+++ b/src/usr/ipmiext/ipmifruinv.C
@@ -1622,10 +1622,22 @@ errlHndl_t membufIpmiFruInv::buildBoardInfoArea(
         //Set formatting data that goes at the beginning of the record
         preFormatProcessing(io_data, true);
 
-        //Set MFG Date/Time - Blank
-        io_data.push_back(0);
-        io_data.push_back(0);
-        io_data.push_back(0);
+        // Set Mfg Build date
+        // Grab VPD data into seperate data vector
+        std::vector<uint8_t> mfgDateData;
+        l_errl = addVpdData(mfgDateData, CVPD::OPFR, CVPD::MB, false, false);
+        if (l_errl)
+        {
+            // The MB keyword was optional on older cards so just ignore
+            //  any errors
+            delete l_errl;
+            l_errl = NULL;
+        }
+        else
+        {
+            // Pass that to the function that sets the Build date
+            setMfgData(io_data, mfgDateData);
+        }
 
         uint8_t l_fru_id = 0xFF;
         // if the centaur_ecid_fru_id is not valid then the centaur is on a


### PR DESCRIPTION
The IPMI FRU message now contains the manufacturing date of
a memory buffer.

Signed-off-by: Artem Senichev <a.senichev@yadro.com>