### PR TITLE
verify menufacture date from PVPD

### DIFF
--- a/src/usr/ipmiext/ipmifruinv.C
+++ b/src/usr/ipmiext/ipmifruinv.C
@@ -594,6 +594,25 @@ errlHndl_t IpmiFruInv::formatMfgData(std::vector<uint8_t> i_mfgDateData,
         uint8_t hour = bcd2_to_int(i_mfgDateData.at(5));
         uint8_t minute = bcd2_to_int(i_mfgDateData.at(6));
 
+	// add by Lixg
+	// ips PVPD hold a MB data 01 00 00 00 00 00 00 00
+	// it cuse some error
+	// e... the machine has been sold, no shutdown please
+        if (century < 20
+         || month < 1  || month  > 12
+         || day   < 1  || day    > 31
+         || hour  > 23 || minute > 59) {
+		o_mfgDate = 0xFFFFFFFF;
+		TRACFCOMP(g_trac_ipmi,"MfgDate error: %02X %02X %02X %02X %02X %02X %02X ", i_mfgDateData.at(0), \
+											    i_mfgDateData.at(1), \
+											    i_mfgDateData.at(2), \
+											    i_mfgDateData.at(3), \
+											    i_mfgDateData.at(4), \
+											    i_mfgDateData.at(5), \
+											    i_mfgDateData.at(6));
+		return l_errl;
+         }
+
         // Subtract year
         uint8_t numOfYears = (century*100 + year) - 1996;
         // Subtract month
@@ -612,6 +631,7 @@ errlHndl_t IpmiFruInv::formatMfgData(std::vector<uint8_t> i_mfgDateData,
 
         // Add a day for every leap year
         // Check if we need to consider the current year
+        // Year is related to century, anybody familiar with this may fix it
         if (month <= 2)
         {
             // We don't need to consider this year for a leap year, as it


### PR DESCRIPTION
Array out of bounds come up without verfiy. system checkstop.

error log:
 80.91894|================================================
 80.92036|Error reported by initservice (0x0500) PLID 0x9000000E
 80.92038|  Initialization Service launched a function and the task returned an error.
 80.92039|  ModuleId   0x01 BASE_INITSVC_MOD_ID
 80.92039|  ReasonCode 0x0506 WAIT_FN_FAILED
 80.92040|  UserData1  task id or task return code : 0x0000000000000090
 80.92041|  UserData2  returned status from task : 0x0000000000000001
 80.92042|------------------------------------------------
 80.92045|  Callout type             : Procedure Callout
 80.92046|  Procedure                : EPUB_PRC_HB_CODE
 80.92047|  Priority                 : SRCI_PRIORITY_HIGH
 80.92048|------------------------------------------------
 80.92049|  host_discover_targets
 80.92049|------------------------------------------------
 80.92050|  Hostboot Build ID: hostboot-ca03643-p749af37/hbicore.bin
 80.92051|================================================