### PR TITLE
errl: Free memory allocated for parsers

### DIFF
--- a/src/usr/errl/plugins/errludparser.H
+++ b/src/usr/errl/plugins/errludparser.H
@@ -80,6 +80,7 @@ static bool myDataParse(\
     {\
         l_rc = true;\
         l_pParser->parse(i_ver, i_parser, i_buffer, i_buflen);\
+        delete l_pParser;\
     }\
     return l_rc;\
 }\


### PR DESCRIPTION
Errl's factory creates new instance of User Defined Data parser
on every call, but doesn't free it after usage.

Signed-off-by: Artem Senichev <a.senichev@yadro.com>