### PR TITLE
Fix data reading from unaligned pointers

### DIFF
--- a/src/usr/errl/plugins/errludbacktrace.H
+++ b/src/usr/errl/plugins/errludbacktrace.H
@@ -113,7 +113,7 @@ public:
         for( int i = 0; i < l_count; i++ )
         {
             // endian convert the stack address
-            uint64_t l_addr  = ntohll(*p64);
+            uint64_t l_addr  = ntohll(UINT64_FROM_PTR(p64));
 
             // get nearest symbol
             const char * l_pSymbol = symTab.nearestSymbol( l_addr );

--- a/src/usr/errl/plugins/errludlogregister.H
+++ b/src/usr/errl/plugins/errludlogregister.H
@@ -79,7 +79,7 @@ public:
         {
             // first is the HUID
             uint32_t *pData = reinterpret_cast<uint32_t *>(pBuf);
-            if (ntohl(*pData) == 0xFFFFFFFF)
+            if (ntohl(UINT32_FROM_PTR(pData)) == 0xFFFFFFFF)
             {
                 i_parser.PrintString("LogRegister",
                             "Target: MASTER_PROCESSOR_CHIP_TARGET_SENTINEL");
@@ -87,7 +87,7 @@ public:
             else
             {
                 i_parser.PrintNumber( "LogRegister",
-                            "Target: HUID = 0x%08X", ntohl(*pData) );
+                            "Target: HUID = 0x%08X", ntohl(UINT32_FROM_PTR(pData)) );
             }
             pData++;
             pBuf += sizeof(*pData);
@@ -199,7 +199,7 @@ public:
                     for (int32_t i = 0;i < numArgs;i++)
                     {
                         std::vector<char> l_traceEntry(20);
-                        sprintf(&(l_traceEntry[0]),"0x%016llX", ntohll(*pData64));
+                        sprintf(&(l_traceEntry[0]),"0x%016llX", ntohll(UINT64_FROM_PTR(pData64)));
                         i_parser.PrintString(addrParams[i], &(l_traceEntry[0]));
 
                         pData64++;

--- a/src/usr/errl/plugins/errluserdetails.H
+++ b/src/usr/errl/plugins/errluserdetails.H
@@ -37,6 +37,88 @@ namespace ERRORLOG
 {
 
 /**
+ * @struct UnalignedData
+ * @brief Structure used for safe assigment from unaligned pointer, it forces
+ *        the compiler to generate extra instructions and satisfy architectural
+ *        alignment requirements.
+ */
+template<typename T> struct UnalignedData {
+    T value;
+} __attribute__ ((packed));
+
+/**
+ * @brief Read integral value from unaligned pointer.
+ *
+ * @param[in] i_pUint64 - Pointer to uint64_t value
+ *
+ * @return uint64_t value from specified pointer
+ */
+inline uint64_t UINT64_FROM_PTR(const void* i_pUint64)
+{
+    return reinterpret_cast<const UnalignedData<uint64_t>*>(i_pUint64)->value;
+}
+
+/**
+ * @brief Read integral value from unaligned pointer.
+ *
+ * @param[in] i_pUint32 - Pointer to uint32_t value
+ *
+ * @return uint32_t value from specified pointer
+ */
+inline uint32_t UINT32_FROM_PTR(const void* i_pUint32)
+{
+    return reinterpret_cast<const UnalignedData<uint32_t>*>(i_pUint32)->value;
+}
+
+/**
+ * @brief Read integral value from unaligned pointer.
+ *
+ * @param[in] i_pUint16 - Pointer to uint16_t value
+ *
+ * @return uint16_t value from specified pointer
+ */
+inline uint16_t UINT16_FROM_PTR(const void* i_pUint16)
+{
+    return reinterpret_cast<const UnalignedData<uint16_t>*>(i_pUint16)->value;
+}
+
+/**
+ * @brief Read integral value from unaligned pointer.
+ *
+ * @param[in] i_pInt64 - Pointer to int64_t value
+ *
+ * @return int64_t value from specified pointer
+ */
+inline int64_t INT64_FROM_PTR(const void* i_pInt64)
+{
+    return reinterpret_cast<const UnalignedData<int64_t>*>(i_pInt64)->value;
+}
+
+/**
+ * @brief Read integral value from unaligned pointer.
+ *
+ * @param[in] i_pInt32 - Pointer to int32_t value
+ *
+ * @return int32_t value from specified pointer
+ */
+inline int32_t INT32_FROM_PTR(const void* i_pInt32)
+{
+    return reinterpret_cast<const UnalignedData<int32_t>*>(i_pInt32)->value;
+}
+
+/**
+ * @brief Read integral value from unaligned pointer.
+ *
+ * @param[in] i_pInt16 - Pointer to int16_t value
+ *
+ * @return int16_t value from specified pointer
+ */
+inline int16_t INT16_FROM_PTR(const void* i_pInt16)
+{
+    return reinterpret_cast<const UnalignedData<int16_t>*>(i_pInt16)->value;
+}
+
+/**
  *
  * @class ErrlUserDetailsParser
  *

--- a/src/usr/hwpf/plat/fapiPlatCreateHwpErrParser.pl
+++ b/src/usr/hwpf/plat/fapiPlatCreateHwpErrParser.pl
@@ -79,7 +79,7 @@ print TGFILE "void fapiParseHwpRc(ErrlUsrParser & i_parser,\n";
 print TGFILE "                    void * i_pBuffer,\n";
 print TGFILE "                    const uint32_t i_buflen)\n";
 print TGFILE "{\n";
-print TGFILE "    uint32_t l_rc = ntohl(*(static_cast<uint32_t *>(i_pBuffer)));\n\n";
+print TGFILE "    uint32_t l_rc = ntohl(UINT32_FROM_PTR(i_pBuffer));\n\n";
 print TGFILE "    switch(l_rc)\n";
 print TGFILE "    {\n";
 
@@ -150,7 +150,7 @@ print TGFILE "    uint8_t * l_pBuffer = static_cast<uint8_t *>(i_pBuffer);\n";
 print TGFILE "    uint32_t l_buflen = i_buflen;\n\n";
 print TGFILE "    // The first uint32_t is the FFDC ID\n";
 print TGFILE "    uint32_t * l_pFfdcId = static_cast<uint32_t *>(i_pBuffer);\n";
-print TGFILE "    uint32_t l_ffdcId = ntohl(*l_pFfdcId);\n";
+print TGFILE "    uint32_t l_ffdcId = ntohl(UINT32_FROM_PTR(l_pFfdcId));\n";
 print TGFILE "    l_pBuffer += sizeof(l_ffdcId);\n";
 print TGFILE "    l_buflen -= sizeof(l_ffdcId);\n";
 print TGFILE "    switch(l_ffdcId)\n";
@@ -217,7 +217,7 @@ foreach my $argnum (1 .. $#ARGV)
         print TGFILE "            if (l_buflen >= POS_LEN)\n";
         print TGFILE "            {\n";
         print TGFILE "                uint32_t * l_pBufferTemp = reinterpret_cast<uint32_t *>(l_pBuffer);\n";
-        print TGFILE "                i_parser.PrintNumber(\"Chip Position:\",\"%X\",ntohl(*l_pBufferTemp));\n";
+        print TGFILE "                i_parser.PrintNumber(\"Chip Position:\",\"%X\",ntohl(UINT32_FROM_PTR(l_pBufferTemp)));\n";
         print TGFILE "                l_pBufferTemp = NULL;\n";
         print TGFILE "                l_pBuffer+= POS_LEN;\n";
         print TGFILE "                l_buflen -= POS_LEN;\n";

--- a/src/usr/targeting/common/xmltohb/xmltohb.pl
+++ b/src/usr/targeting/common/xmltohb/xmltohb.pl
@@ -2274,7 +2274,7 @@ sub writeAttrErrlHFile {
     print $outFile "    for (; (l_ptr + sizeof(uint32_t)) <= ((uint8_t*)i_pBuffer + i_buflen); )\n";
     print $outFile "    {\n";
     print $outFile "        // first 4 bytes is the attr enum\n";
-    print $outFile "        uint32_t attrEnum = ntohl(*(uint32_t *)l_ptr);\n";
+    print $outFile "        uint32_t attrEnum = ntohl(UINT32_FROM_PTR(l_ptr));\n";
     print $outFile "        l_ptr += sizeof(attrEnum);\n";
     print $outFile "\n";
     print $outFile "        switch (attrEnum) {\n";
@@ -2404,49 +2404,49 @@ sub writeAttrErrlHFile {
             elsif (exists $attribute->{simpleType}->{uint16_t}) {
                 print $outFile "              l_traceEntry.resize(10+offset + $total_count * 7);\n";
                 print $outFile "              for (uint32_t i = 0;i<$total_count;i++) {\n";
-                print $outFile "                  sprintf(&(l_traceEntry[offset+i*7]), \"0x%.4X \", ntohs(*(((uint16_t *)l_ptr)+i)));\n";
+                print $outFile "                  sprintf(&(l_traceEntry[offset+i*7]), \"0x%.4X \", ntohs(UINT16_FROM_PTR(reinterpret_cast<const uint16_t*>(l_ptr) + i)));\n";
                 print $outFile "              }\n";
                 print $outFile "              l_ptr += $total_count * sizeof(uint16_t);\n";
             }
             elsif (exists $attribute->{simpleType}->{uint32_t}) {
                 print $outFile "              l_traceEntry.resize(10+offset + $total_count * 11);\n";
                 print $outFile "              for (uint32_t i = 0;i<$total_count;i++) {\n";
-                print $outFile "                  sprintf(&(l_traceEntry[offset+i*11]), \"0x%.8X \", ntohl(*(((uint32_t *)l_ptr)+i)));\n";
+                print $outFile "                  sprintf(&(l_traceEntry[offset+i*11]), \"0x%.8X \", ntohl(UINT32_FROM_PTR(reinterpret_cast<const uint32_t*>(l_ptr)+i)));\n";
                 print $outFile "              }\n";
                 print $outFile "              l_ptr += $total_count * sizeof(uint32_t);\n";
             }
             elsif (exists $attribute->{simpleType}->{uint64_t}) {
                 print $outFile "              l_traceEntry.resize(10+offset + $total_count * 19);\n";
                 print $outFile "              for (uint32_t i = 0;i<$total_count;i++) {\n";
-                print $outFile "                  sprintf(&(l_traceEntry[offset+i*19]), \"0x%.16llX \", ntohll(*(((uint64_t *)l_ptr)+i)));\n";
+                print $outFile "                  sprintf(&(l_traceEntry[offset+i*19]), \"0x%.16llX \", ntohll(UINT64_FROM_PTR(reinterpret_cast<const uint64_t*>(l_ptr)+i)));\n";
                 print $outFile "              }\n";
                 print $outFile "              l_ptr += $total_count * sizeof(uint64_t);\n";
             }
             elsif (exists $attribute->{simpleType}->{int8_t}) {
                 print $outFile "              l_traceEntry.resize(10+offset + $total_count * 5);\n";
                 print $outFile "              for (uint32_t i = 0;i<$total_count;i++) {\n";
-                print $outFile "                  sprintf(&(l_traceEntry[offset+i*5]), \"0x%.2X \", *(((uint8_t *)l_ptr)+i));\n";
+                print $outFile "                  sprintf(&(l_traceEntry[offset+i*5]), \"0x%.2X \", *(((int8_t *)l_ptr)+i));\n";
                 print $outFile "              }\n";
                 print $outFile "              l_ptr += $total_count * sizeof(uint8_t);\n";
             }
             elsif (exists $attribute->{simpleType}->{int16_t}) {
                 print $outFile "              l_traceEntry.resize(10+offset + $total_count * 7);\n";
                 print $outFile "              for (uint32_t i = 0;i<$total_count;i++) {\n";
-                print $outFile "                  sprintf(&(l_traceEntry[offset+i*7]), \"0x%.4X \", ntohs(*(((int16_t *)l_ptr)+i)));\n";
+                print $outFile "                  sprintf(&(l_traceEntry[offset+i*7]), \"0x%.4X \", ntohs(INT16_FROM_PTR(reinterpret_cast<const int16_t*>(l_ptr)+i)));\n";
                 print $outFile "              }\n";
                 print $outFile "              l_ptr += $total_count * sizeof(int16_t);\n";
             }
             elsif (exists $attribute->{simpleType}->{int32_t}) {
                 print $outFile "              l_traceEntry.resize(10+offset + $total_count * 11);\n";
                 print $outFile "              for (uint32_t i = 0;i<$total_count;i++) {\n";
-                print $outFile "                  sprintf(&(l_traceEntry[offset+i*11]), \"0x%.8X \", ntohl(*(((int32_t *)l_ptr)+i)));\n";
+                print $outFile "                  sprintf(&(l_traceEntry[offset+i*11]), \"0x%.8X \", ntohl(INT32_FROM_PTR(reinterpret_cast<const int32_t*>(l_ptr)+i)));\n";
                 print $outFile "              }\n";
                 print $outFile "              l_ptr += $total_count * sizeof(int32_t);\n";
             }
             elsif (exists $attribute->{simpleType}->{int64_t}) {
                 print $outFile "              l_traceEntry.resize(10+offset + $total_count * 19);\n";
                 print $outFile "              for (uint32_t i = 0;i<$total_count;i++) {\n";
-                print $outFile "                  sprintf(&(l_traceEntry[offset+i*19]), \"0x%.16llX \", ntohll(*(((int64_t *)l_ptr)+i)));\n";
+                print $outFile "                  sprintf(&(l_traceEntry[offset+i*19]), \"0x%.16llX \", ntohll(INT64_FROM_PTR(reinterpret_cast<const int64_t*>(l_ptr)+i)));\n";
                 print $outFile "              }\n";
                 print $outFile "              l_ptr += $total_count * sizeof(int64_t);\n";
             }
@@ -2507,7 +2507,7 @@ sub writeAttrErrlHFile {
         elsif(exists $attribute->{nativeType}) {
             print $outFile "              //nativeType\n";
             print $outFile "              pLabel = \"",$attribute->{id},"\";\n";
-            print $outFile "              sprintf(&(l_traceEntry[0]), \"%d\", *((int32_t *)l_ptr));\n";
+            print $outFile "              sprintf(&(l_traceEntry[0]), \"%d\", INT32_FROM_PTR(l_ptr));\n";
             print $outFile "              l_ptr += sizeof(uint32_t);\n";
         }
         # just in case, nothing..
@@ -3196,10 +3196,10 @@ sub writeTargetErrlHFile {
     print $outFile "    // while there is still at least 1 word of data left\n";
     print $outFile "    for (; (l_ptr32 + 1) <= (uint32_t *)((uint8_t*)i_pBuffer + i_buflen); )\n";
     print $outFile "    {\n";
-    print $outFile "      if (*l_ptr32 == 0xFFFFFFFF) { // special - master\n";
+    print $outFile "      if (UINT32_FROM_PTR(l_ptr32) == 0xFFFFFFFF) { // special - master\n";
     print $outFile "        i_parser.PrintString(\"Target\", \"MASTER_PROCESSOR_CHIP_TARGET_SENTINEL\");\n";
     print $outFile "        l_ptr32++; // past the marker\n";
-    print $outFile "      } else if (*l_ptr32 == TargetLabel_t::LABEL_TAG) {\n";
+    print $outFile "      } else if (UINT32_FROM_PTR(l_ptr32) == TargetLabel_t::LABEL_TAG) {\n";
     print $outFile "        TargetLabel_t* tmp_label = reinterpret_cast<TargetLabel_t*>(l_ptr32);\n";
     print $outFile "        memcpy( l_label, tmp_label->x, sizeof(l_label)-1 );\n";
     print $outFile "        l_ptr32 += (sizeof(TargetLabel_t)/sizeof(uint32_t));\n";
@@ -3207,11 +3207,11 @@ sub writeTargetErrlHFile {
 
     print $outFile "        // first 4 are always the same\n";
     print $outFile "        if ((l_ptr32 + 4) <= (uint32_t *)((uint8_t*)i_pBuffer + i_buflen)) {\n";
-    print $outFile "            i_parser.PrintNumber( l_label, \"HUID = 0x%08X\", ntohl(*l_ptr32) );\n";
+    print $outFile "            i_parser.PrintNumber( l_label, \"HUID = 0x%08X\", ntohl(UINT32_FROM_PTR(l_ptr32)) );\n";
     print $outFile "            l_ptr32++;\n";
 
     # find CLASS
-    print $outFile "            switch (ntohl(*l_ptr32)) { // CLASS\n";
+    print $outFile "            switch (ntohl(UINT32_FROM_PTR(l_ptr32))) { // CLASS\n";
     foreach my $enumerationType (@{$attributes->{enumerationType}})
     {
       if( $enumerationType->{id} eq "CLASS" ) {
@@ -3230,7 +3230,7 @@ sub writeTargetErrlHFile {
     print $outFile "            l_ptr32++;\n";
 
     # find TYPE
-    print $outFile "            switch (ntohl(*l_ptr32)) { // TYPE\n";
+    print $outFile "            switch (ntohl(UINT32_FROM_PTR(l_ptr32))) { // TYPE\n";
     foreach my $enumerationType (@{$attributes->{enumerationType}})
     {
       if( $enumerationType->{id} eq "TYPE" ) {
@@ -3249,7 +3249,7 @@ sub writeTargetErrlHFile {
     print $outFile "            l_ptr32++;\n";
 
     # find MODEL
-    print $outFile "            switch (ntohl(*l_ptr32)) { // MODEL\n";
+    print $outFile "            switch (ntohl(UINT32_FROM_PTR(l_ptr32))) { // MODEL\n";
     foreach my $enumerationType (@{$attributes->{enumerationType}})
     {
       if( $enumerationType->{id} eq "MODEL" ) {
@@ -3287,7 +3287,7 @@ sub writeTargetErrlHFile {
         }
     }
 
-    print $outFile "                uint32_t l_pathType = ntohl(*l_ptr32);\n";
+    print $outFile "                uint32_t l_pathType = ntohl(UINT32_FROM_PTR(l_ptr32));\n";
     print $outFile "                if ((l_pathType == $attrPhysPath) || // ATTR_PHYS_PATH\n";
     print $outFile "                    (l_pathType == $attrAffinityPath))   // ATTR_AFFINITY_PATH\n";
     print $outFile "                {\n";


### PR DESCRIPTION
Some architectures (like an ARM used in OpenBMC) do not support
unaligned memory access. On these systems, reading an integral
value from an unaligned pointer leads to undefined behavior.

This patch doesn't change existing functionality, but forces the
compiler to generate extra instructions to satisfy architectural
alignment requirements.

Signed-off-by: Artem Senichev <a.senichev@yadro.com>