### PR TITLE
Debug Scripts: Remove deprecated defined(@array)

### DIFF
--- a/src/build/debug/Hostboot/PrintVMM.pm
+++ b/src/build/debug/Hostboot/PrintVMM.pm
@@ -73,7 +73,7 @@ sub main
     my @segment_manager_addr = ::findPointer("SGMNTMGR",
                    "Singleton<SegmentManager>::instance()::instance");
 
-    if (not defined @segment_manager_addr)
+    if (not @segment_manager_addr)
     {
 	::userDisplay "   VirtualToPhy: Cannot find Device Segment symbol.\n"; die;
     }

--- a/src/build/debug/Hostboot/_DebugFrameworkVMM.pm
+++ b/src/build/debug/Hostboot/_DebugFrameworkVMM.pm
@@ -404,7 +404,7 @@ sub getPhysicalAddr
                    "Singleton<SegmentManager>::instance()::instance");
 
 
-    if (not defined @segment_manager_addr)
+    if (not @segment_manager_addr)
     {
         ::userDisplay "   VirtualToPhy: Cannot find SegmentManager symbol.\n";
         return NotFound;


### PR DESCRIPTION
The use of 'defined(@array)' and 'defined(%hash)' have been deprecated
since Perl 5.6.1, raised warnings since 5.16 and are treated as fatal
errors since Perl 5.22.0.

https://perldoc.perl.org/perl5220delta.html#defined(%40array)-and-defined(%25hash)-are-now-fatal-errors

Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>