### PR TITLE
ebmc: PEL: create a basic setuptools framework

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,33 @@
+import os.path
+from setuptools import setup
+
+dirmap = {
+    "bxxxx": "src/usr/secureboot",
+    "bzzzz": "src/usr/hdat",
+}
+
+
+def get_package_name(dirmap_key):
+    return "udparsers.{}".format(dirmap_key)
+
+
+def get_package_dirent(dirmap_item):
+    package_name = get_package_name(dirmap_item[0])
+    package_dir = os.path.join(dirmap_item[1], 'plugins/ebmc')
+    return (package_name, package_dir)
+
+
+def get_packages():
+    return map(get_package_name, dirmap.keys())
+
+
+def get_package_dirs():
+    return map(get_package_dirent, dirmap.items())
+
+
+setup(
+        name="Hostboot",
+        version="0.1",
+        packages=list(get_packages()),
+        package_dir=dict(get_package_dirs())
+)

--- a/src/usr/hdat/plugins/ebmc/bzzzz.py
+++ b/src/usr/hdat/plugins/ebmc/bzzzz.py
@@ -1,0 +1,4 @@
+def parseUDToJson(subtype, version, data):
+    return {
+        "Hello": "World"
+    }

--- a/src/usr/secureboot/plugins/ebmc/bxxxx.py
+++ b/src/usr/secureboot/plugins/ebmc/bxxxx.py
@@ -1,0 +1,4 @@
+def parseUDToJson(subtype, version, data):
+    return {
+        "Hello": "World"
+    }


### PR DESCRIPTION
The eBMC PEL implementation features a python hook that we can implement
to pretty-print our PEL user data sections.  Add a basic setup.py script
and a couple example component parser files to showcase how setuptools
setup.py files are written.

Note that the example component parsers are examples only to the level
of installing python modules - they probably do not implement the
correct hook API expected by the OpenBMC PEL hook!!!

Signed-off-by: Brad Bishop <bradleyb@fuzziesquirrel.com>