### PR TITLE
Support get SMS string from fru vpd

### DIFF
--- a/src/include/usr/vpd/pvpdenums.H
+++ b/src/include/usr/vpd/pvpdenums.H
@@ -42,6 +42,7 @@ namespace PVPD
         VSYS        = 0x01,
         LXR0        = 0x02,
         PSPD        = 0x03,
+        UTIL        = 0x04,
         // Last Record
         PVPD_LAST_RECORD,
         PVPD_TEST_RECORD,   // Test purposes ONLY!
@@ -100,6 +101,8 @@ namespace PVPD
         TN         = 0x28,
         WN         = 0x29,
         pdD        = 0x2A,
+        F5         = 0x2B,
+        F6         = 0x2C,
 
         // Last Keyword
         PVPD_LAST_KEYWORD,

--- a/src/usr/pldm/extended/hb_fru.C
+++ b/src/usr/pldm/extended/hb_fru.C
@@ -84,6 +84,7 @@ const std::map<uint32_t, std::vector<uint16_t> > record_keyword_field_map {
   { VSYS, { std::begin(valid_vsys_keywords), std::end(valid_vsys_keywords) } },
   { LXR0, { std::begin(valid_lxr0_keywords), std::end(valid_lxr0_keywords) } },
   { PSPD, { std::begin(valid_pspd_keywords), std::end(valid_pspd_keywords) } },
+  { UTIL, { std::begin(valid_util_keywords), std::end(valid_util_keywords) } },
 };
 
 // Map to identify the list of pound keywords to ADD

--- a/src/usr/pldm/extended/pldm_fru_to_ipz_mapping.H
+++ b/src/usr/pldm/extended/pldm_fru_to_ipz_mapping.H
@@ -49,6 +49,7 @@ enum valid_records : uint32_t
     VSYS = 0x56535953,
     LXR0 = 0x4C585230,
     PSPD = 0x50535044,
+    UTIL = 0x5554494C,
 };
 
 enum valid_special_keywords : uint16_t
@@ -101,6 +102,33 @@ const uint16_t valid_vsys_keywords[]
                   0x544E,  // TN
                   0x574E   // WN
                 };
+
+const uint16_t valid_util_keywords[]
+                 { 0xFFFF,  // invalid
+                   0xFFFF,  // invalid
+                   0x5254,  // RT
+                   0x4430,  // D0
+                   0x4431,  // D1
+                   0x4432,  // D2
+                   0x4433,  // D3
+                   0x4434,  // D4
+                   0x4435,  // D5
+                   0x4436,  // D6
+                   0x4437,  // D7
+                   0x4438,  // D8
+                   0x4439,  // D9
+                   0x4630,  // F0
+                   0x4631,  // F1
+                   0x4632,  // F2
+                   0x4633,  // F3
+                   0x4634,  // F4
+                   0x4635,  // F5
+                   0x4636,  // F6
+                   0x4637,  // F7
+                   0x4638,  // F8
+                   0x4639,  // F9
+                   0x5046,  // PF
+                  };
 
 // Must match valid_vsys_keywords and PLDM FRU IPZ Keyword Mapping Doc
 enum valid_vsys_keywords_values

--- a/src/usr/vpd/pvpd.H
+++ b/src/usr/vpd/pvpd.H
@@ -60,6 +60,7 @@ namespace PVPD
         { VSYS, "VSYS" },
         { LXR0, "LXR0" },
         { PSPD, "PSPD" },
+        { UTIL, "UTIL" },
         // -------------------------------------------------------------------
         // DO NOT USE!!  This is for test purposes ONLY!
         { PVPD_TEST_RECORD, "TEST" },
@@ -121,6 +122,8 @@ namespace PVPD
         { TN,  "TN" },
         { WN,  "WN" },
         { pdD, "#D" },
+        { F5,  "F5" },
+        { F6,  "F6" },
 
         // -------------------------------------------------------------------
         // DO NOT USE!!  This is for test purposes ONLY!


### PR DESCRIPTION
Add support for UTIL::F5 and UTIL::F6
Hostboot will get F5 and F6 from BMC through PLDM and cache it to the PVPD. Finally,F5 and F6 will be merged together and write to hdat system ipl parameter.